### PR TITLE
feat: AI-powered related query suggestions after search

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mcp": "tsx mcp-server/index.ts",
     "dev:all": "concurrently \"npm run server\" \"npm run dev\"",
     "test:search": "tsx scripts/test-search.ts",
+    "test:suggestions": "tsx scripts/test-search.ts \"Stellar blockchain\" --count 3",
     "deploy": "npm run build && vercel --prod"
   },
   "dependencies": {

--- a/scripts/test-search.ts
+++ b/scripts/test-search.ts
@@ -107,6 +107,53 @@ async function runSearch() {
     console.log('✗ Groq AI unavailable (check GROQ_API_KEY)')
   }
 
+  // 4. Test AI suggestions — opt-in via ?suggestions=1
+  console.log('\n── AI suggestions test ──')
+
+  // 4a. With ?suggestions=1 — should return 3 suggestions
+  const t1 = Date.now()
+  const suggParams = new URLSearchParams({ q: query, count: String(count), suggestions: '1' })
+  const suggRes = await fetch(`${SERVER}/search?${suggParams}`)
+  const suggMs = Date.now() - t1
+
+  if (suggRes.status === 402) {
+    console.log('⚡ Got 402 (payment required) — suggestions test skipped in unauthenticated mode')
+  } else if (!suggRes.ok) {
+    console.error('✗ Suggestions request failed:', suggRes.status)
+  } else {
+    const suggData = await suggRes.json()
+    const suggestions: string[] = suggData.suggestions ?? []
+
+    if (!Array.isArray(suggestions)) {
+      console.error('✗ suggestions field is not an array')
+      process.exit(1)
+    }
+    if (suggestions.length !== 3) {
+      console.error(`✗ Expected 3 suggestions, got ${suggestions.length}`)
+      process.exit(1)
+    }
+    if (suggMs > 500) {
+      console.warn(`⚠  Suggestions added ${suggMs - ms}ms — exceeds 500ms budget (total: ${suggMs}ms)`)
+    }
+
+    console.log(`\n✓ Got ${suggestions.length} AI suggestions (${suggMs}ms total):`)
+    suggestions.forEach((s, i) => console.log(`   ${i + 1}. ${s}`))
+  }
+
+  // 4b. Without ?suggestions=1 — should return empty array
+  const noSuggParams = new URLSearchParams({ q: query, count: '1' })
+  const noSuggRes = await fetch(`${SERVER}/search?${noSuggParams}`)
+
+  if (noSuggRes.status !== 402 && noSuggRes.ok) {
+    const noSuggData = await noSuggRes.json()
+    const noSuggestions: string[] = noSuggData.suggestions ?? []
+    if (noSuggestions.length !== 0) {
+      console.error(`✗ Expected 0 suggestions without ?suggestions=1, got ${noSuggestions.length}`)
+      process.exit(1)
+    }
+    console.log('✓ No suggestions returned when ?suggestions=1 is omitted')
+  }
+
   console.log('\n✅ All tests passed!\n')
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -154,6 +154,34 @@ app.get('/search', async (req: Request, res: Response) => {
     // The real tx hash comes from the X-PAYMENT-RESPONSE header set by the facilitator
     const txHash = (req.headers['x-payment-response'] as string) || null
 
+    // ── Optional AI suggestions via Groq ──────────────────────────────────
+    let suggestions: string[] = []
+    if (req.query.suggestions === '1' && results.length > 0) {
+      try {
+        const topSnippets = results.slice(0, 3).map((r: any) => r.description).join(' | ')
+        const suggCompletion = await groq.chat.completions.create({
+          model: 'llama-3.3-70b-versatile',
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a search assistant. Given a query and top result snippets, return exactly 3 related search queries the user might want to explore next. Output only a JSON array of 3 strings, no explanation.',
+            },
+            {
+              role: 'user',
+              content: `Query: "${q.trim()}"\nTop results: ${topSnippets}`,
+            },
+          ],
+          max_tokens: 120,
+          temperature: 0.7,
+        })
+        const raw = suggCompletion.choices[0]?.message?.content || '[]'
+        const match = raw.match(/\[[\s\S]*\]/)
+        if (match) suggestions = JSON.parse(match[0]).slice(0, 3)
+      } catch (err: any) {
+        console.warn('[suggestions] Groq error:', err.message)
+      }
+    }
+
     return res.json({
       query: q.trim(),
       results,
@@ -163,6 +191,7 @@ app.get('/search', async (req: Request, res: Response) => {
       currency: 'USDC',
       txHash,
       latencyMs,
+      suggestions,
     })
   } catch (err: any) {
     console.error('[search error]', err.message)

--- a/src/components/search/SearchSuggestions.tsx
+++ b/src/components/search/SearchSuggestions.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion'
+import { Sparkles } from 'lucide-react'
 
-const SUGGESTIONS = [
+const STATIC_SUGGESTIONS = [
   'x402 payment protocol Stellar',
   'Soroban smart contracts tutorial',
   'AI agent autonomous payments 2025',
@@ -11,9 +12,14 @@ const SUGGESTIONS = [
 
 interface Props {
   onSelect: (query: string) => void
+  /** AI-generated suggestions shown after a search completes */
+  aiSuggestions?: string[]
 }
 
-export function SearchSuggestions({ onSelect }: Props) {
+export function SearchSuggestions({ onSelect, aiSuggestions }: Props) {
+  const isAi = aiSuggestions && aiSuggestions.length > 0
+  const items = isAi ? aiSuggestions : STATIC_SUGGESTIONS
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -21,26 +27,32 @@ export function SearchSuggestions({ onSelect }: Props) {
       exit={{ opacity: 0 }}
       className="space-y-3"
     >
-      <p className="font-display text-xs text-white/25 tracking-widest">TRY THESE</p>
+      <div className="flex items-center gap-1.5">
+        {isAi && <Sparkles className="w-3 h-3 text-neon-amber/60" />}
+        <p className="font-display text-xs text-white/25 tracking-widest">
+          {isAi ? 'YOU MIGHT ALSO SEARCH FOR' : 'TRY THESE'}
+        </p>
+      </div>
+
       <div className="flex flex-wrap gap-2">
-        {SUGGESTIONS.map((q, i) => (
+        {items.map((q, i) => (
           <motion.button
             key={q}
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: i * 0.04 }}
+            transition={{ delay: i * 0.06 }}
             onClick={() => onSelect(q)}
             className="px-3 py-1.5 rounded-lg text-xs font-display tracking-wide transition-all text-white/40 hover:text-neon-cyan/80"
             style={{ border: '1px solid rgba(255,255,255,0.08)' }}
             onMouseEnter={e => {
               const el = e.currentTarget as HTMLButtonElement
-              el.style.borderColor = 'rgba(0,245,255,0.25)'
-              el.style.background = 'rgba(0,245,255,0.04)'
+              el.style.borderColor = isAi ? 'rgba(255,176,0,0.3)' : 'rgba(0,245,255,0.25)'
+              el.style.background   = isAi ? 'rgba(255,176,0,0.05)' : 'rgba(0,245,255,0.04)'
             }}
             onMouseLeave={e => {
               const el = e.currentTarget as HTMLButtonElement
               el.style.borderColor = 'rgba(255,255,255,0.08)'
-              el.style.background = 'transparent'
+              el.style.background  = 'transparent'
             }}
           >
             {q}

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -42,20 +42,21 @@ export interface SearchSession {
   status: 'idle' | 'searching' | 'complete' | 'error'
   error?: string
   durationMs?: number
+  suggestions: string[]
 }
 
 export function useSearch(walletAddress: string | null = null) {
   const [session, setSession] = useState<SearchSession>({
-    query: '', results: [], txHash: null, paidAmount: null, status: 'idle',
+    query: '', results: [], txHash: null, paidAmount: null, status: 'idle', suggestions: [],
   })
 
   const search = useCallback(async (query: string, count = 5) => {
     if (!query.trim()) return
 
-    setSession({ query, results: [], txHash: null, paidAmount: null, status: 'searching' })
+    setSession({ query, results: [], txHash: null, paidAmount: null, status: 'searching', suggestions: [] })
 
     const t0     = Date.now()
-    const params = new URLSearchParams({ q: query, count: String(count) })
+    const params = new URLSearchParams({ q: query, count: String(count), suggestions: '1' })
 
     try {
       if (!walletAddress) throw new Error('Connect your Freighter wallet first.')
@@ -121,7 +122,7 @@ export function useSearch(walletAddress: string | null = null) {
         const data = await firstRes.json()
         return setSession({
           query, results: data.results ?? [], txHash: null,
-          paidAmount: null, status: 'complete', durationMs: Date.now() - t0,
+          paidAmount: null, status: 'complete', durationMs: Date.now() - t0, suggestions: data.suggestions ?? [],
         })
       }
 
@@ -162,6 +163,7 @@ export function useSearch(walletAddress: string | null = null) {
         paidAmount:  data.paidAmount ?? null,
         status:      'complete',
         durationMs:  Date.now() - t0,
+        suggestions: data.suggestions ?? [],
       })
 
     } catch (err: any) {
@@ -175,7 +177,7 @@ export function useSearch(walletAddress: string | null = null) {
   }, [walletAddress])
 
   const reset = useCallback(() => {
-    setSession({ query: '', results: [], txHash: null, paidAmount: null, status: 'idle' })
+    setSession({ query: '', results: [], txHash: null, paidAmount: null, status: 'idle', suggestions: [] })
   }, [])
 
   return { session, search, reset }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -123,6 +123,12 @@ export function SearchPage({ wallet, onConnectWallet }: Props) {
               </motion.div>
             )}
 
+            {session.status === 'complete' && session.suggestions.length > 0 && (
+              <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }}>
+                <SearchSuggestions onSelect={handleSearch} aiSuggestions={session.suggestions} />
+              </motion.div>
+            )}
+
             {(session.status === 'complete' || session.status === 'error') && (
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center pt-2">
                 <button onClick={reset} className="font-display text-xs text-white/25 hover:text-neon-cyan transition-colors tracking-widest">


### PR DESCRIPTION
# feat: AI-Powered Related Query Suggestions After Search

Closes #58 

## Summary

After a search completes, StellarSearch now uses Groq (Llama 3.3 70B) to automatically
generate 3 related query suggestions displayed as clickable chips below the results
under the label "YOU MIGHT ALSO SEARCH FOR". The feature is opt-in via `?suggestions=1`
to avoid adding latency to every request.

---

## Problem

After a search completed, users had no guidance on where to go next. The only
suggestions shown were a static hardcoded list displayed before any search was made.
There was no contextual, AI-driven discovery path based on what the user just searched
for and what results came back.

---

## Solution

### Server (`server/index.ts`)

After Serper.dev returns results, if `?suggestions=1` is present in the query string,
the server makes an additional Groq call with the original query and the top 3 result
snippets as context. Groq returns a JSON array of 3 related queries which is appended
to the search response as `suggestions: string[]`.

- Groq is prompted to return **only** a JSON array — no prose, no explanation
- The response is parsed with a regex match on `[...]` to safely extract the array
- Any Groq error is caught and logged — the response falls back to `suggestions: []`
- When `?suggestions=1` is omitted, Groq is never called and `suggestions` is always `[]`

### Hook (`src/hooks/useSearch.ts`)

- `SearchSession` type extended with `suggestions: string[]`
- `suggestions=1` is always appended to the search params
- All `setSession` calls initialise and populate `suggestions` from the response

### Component (`src/components/search/SearchSuggestions.tsx`)

- Accepts an optional `aiSuggestions?: string[]` prop
- When AI suggestions are present, renders them instead of the static list
- Label changes from `TRY THESE` to `YOU MIGHT ALSO SEARCH FOR` with a sparkle icon
- Hover accent colour shifts to amber to visually distinguish AI suggestions from
  the static pre-search chips

### Page (`src/pages/SearchPage.tsx`)

- AI suggestion chips are rendered below search results when
  `session.status === 'complete'` and `session.suggestions.length > 0`
- Clicking any chip calls `handleSearch(query)` which triggers a full new x402
  payment flow and search

### Tests (`scripts/test-search.ts`)

Extended the existing e2e test script with a dedicated suggestions test block:

- **4a** — verifies `?suggestions=1` returns exactly 3 strings in the `suggestions` array
- **4b** — verifies omitting `?suggestions=1` returns an empty array (opt-in is enforced)
- Emits a warning if the suggestions call adds more than 500ms to total response time
- Gracefully skips assertions if the server returns 402 (unauthenticated/CI mode)

A `test:suggestions` npm script was added for convenience:

```bash
npm run test:suggestions
