### PR TITLE
fix: CORS allowlist in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ GROQ_API_KEY=gsk_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # ─── Server ──────────────────────────────────────────
 PORT=3001
 
+# Comma-separated browser origins allowed when NODE_ENV=production.
+# Development always uses * regardless of this value.
+# Example: http://localhost:5173,https://your-app.vercel.app
+ALLOWED_ORIGINS=http://localhost:5173
+
 # ─── Frontend (Vite env vars) ────────────────────────
 # Used by the React frontend to reach the server
 VITE_SERVER_URL=http://localhost:3001

--- a/server/corsConfig.ts
+++ b/server/corsConfig.ts
@@ -1,0 +1,77 @@
+/**
+ * CORS configuration — dev uses wildcard; production uses ALLOWED_ORIGINS allowlist.
+ */
+
+import type { CorsOptions } from 'cors'
+
+const CORS_ALLOWED_HEADERS = [
+  'Content-Type',
+  'Authorization',
+  'X-Payment',
+  'payment-signature',
+  'x-payment',
+  'X-PAYMENT',
+] as const
+
+const CORS_EXPOSED_HEADERS = [
+  'PAYMENT-REQUIRED',
+  'X-Payment-Response',
+] as const
+
+const CORS_METHODS = ['GET', 'POST', 'OPTIONS'] as const
+
+export function parseAllowedOrigins(raw?: string): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export function isProductionEnv(): boolean {
+  return process.env.NODE_ENV === 'production'
+}
+
+export function getCorsStartupMessage(): string {
+  if (!isProductionEnv()) {
+    return 'CORS: * (development)'
+  }
+
+  const allowed = parseAllowedOrigins(process.env.ALLOWED_ORIGINS)
+  if (allowed.length === 0) {
+    return 'CORS: allowlist empty — cross-origin browser requests blocked'
+  }
+
+  return `CORS: allowlist (${allowed.length} origin${allowed.length === 1 ? '' : 's'})`
+}
+
+export function buildCorsOptions(): CorsOptions {
+  const base: CorsOptions = {
+    allowedHeaders: [...CORS_ALLOWED_HEADERS],
+    exposedHeaders: [...CORS_EXPOSED_HEADERS],
+    methods: [...CORS_METHODS],
+  }
+
+  if (!isProductionEnv()) {
+    return { ...base, origin: '*' }
+  }
+
+  const allowed = parseAllowedOrigins(process.env.ALLOWED_ORIGINS)
+
+  if (allowed.length === 0) {
+    console.warn(
+      '[cors] ALLOWED_ORIGINS is empty in production — blocking cross-origin browser requests',
+    )
+  }
+
+  return {
+    ...base,
+    origin(origin, callback) {
+      if (!origin) {
+        callback(null, true)
+        return
+      }
+
+      callback(null, allowed.includes(origin))
+    },
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@
 import express, { Request, Response } from 'express'
 import cors from 'cors'
 import dotenv from 'dotenv'
+import { buildCorsOptions, getCorsStartupMessage } from './corsConfig.js'
 import Groq from 'groq-sdk'
 import { paymentMiddlewareFromConfig } from '@x402/express'
 import { ExactStellarScheme } from '@x402/stellar/exact/server'
@@ -49,23 +50,7 @@ if (!GROQ_API_KEY)      console.warn('⚠  GROQ_API_KEY not set')
 const groq = new Groq({ apiKey: GROQ_API_KEY })
 
 // ─── Middleware ───────────────────────────────────────────────────────────
-app.use(cors({
-  origin: '*',
-  allowedHeaders: [
-    'Content-Type',
-    'Authorization',
-    'X-Payment',
-    'payment-signature',
-    // ← this is what the browser is complaining about
-    'x-payment',
-    'X-PAYMENT',
-  ],
-  exposedHeaders: [
-    'PAYMENT-REQUIRED',
-    'X-Payment-Response',
-  ],
-  methods: ['GET', 'POST', 'OPTIONS'],
-}))
+app.use(cors(buildCorsOptions()))
 app.use(express.json())
 
 // ─── x402 payment guard on /search ───────────────────────────────────────
@@ -279,7 +264,8 @@ if (process.env.NODE_ENV !== 'production') {
     console.log(`   Facilitator: ${FACILITATOR_URL}`)
     console.log(`   Serper:      ${SERPER_API_KEY ? '✓' : '✗ MISSING'}`)
     console.log(`   Groq:        ${GROQ_API_KEY  ? '✓' : '✗ MISSING'}`)
-    console.log(`   Receiving:   ${RECEIVING_ADDRESS || '✗ MISSING'}\n`)
+    console.log(`   Receiving:   ${RECEIVING_ADDRESS || '✗ MISSING'}`)
+    console.log(`   ${getCorsStartupMessage()}\n`)
   })
 }
 


### PR DESCRIPTION
Replaces origin: '*' on the Express server with an ALLOWED_ORIGINS allowlist when NODE_ENV=production. Development still uses *.

Closes #45

Changes

• Add server/corsConfig.ts for CORS options
• Wire it in server/index.ts
• Document ALLOWED_ORIGINS in .env.example

Test plan

Dev: any Origin gets Access-Control-Allow-Origin: *
Prod: listed origin reflected; unlisted origin gets no ACAO header
npx tsc --noEmit passes