### PR TITLE
Stellar Wave bundle: q sanitisation, zero-balance banner, image_search & news_search MCP tools

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -68,6 +68,21 @@ Use for visual references, photos, diagrams, or anything where you need image re
       },
     },
     {
+      name: 'news_search',
+      description: `Search recent news articles via StellarSearch. Automatically pays ${AMOUNT_USDC} USDC on Stellar (x402 protocol).
+Returns articles with title, URL, snippet, publication date, and source via the Serper.dev news API.
+Use for breaking stories, current events, and time-sensitive reporting.`,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'News search query' },
+          count: { type: 'number', description: 'Results count (1–20, default 10)', default: 10 },
+          freshness: { type: 'string', enum: ['pd', 'pw', 'pm'], description: 'Age: pd=day, pw=week, pm=month' },
+        },
+        required: ['query'],
+      },
+    },
+    {
       name: 'ai_summarize',
       description: 'Use Groq (Llama 3) to summarise or analyse text. Free — no payment required.',
       inputSchema: {
@@ -178,6 +193,49 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
     } catch (err: any) {
       return { content: [{ type: 'text', text: `Image search failed: ${err.message}` }], isError: true }
+    }
+  }
+
+  // ── news_search ───────────────────────────────────────────────────────
+  if (name === 'news_search') {
+    const { query, count = 10, freshness } = args as {
+      query: string; count?: number; freshness?: string
+    }
+
+    try {
+      const safeCount = Math.min(Math.max(parseInt(String(count)) || 10, 1), 20)
+      const params = new URLSearchParams({ q: query, count: String(safeCount) })
+      if (freshness) params.set('freshness', freshness)
+
+      const res = await fetch(`${SERVER_URL}/news?${params}`)
+
+      if (!res.ok) {
+        const e: any = await res.json().catch(() => ({}))
+        throw new Error(e.error || `HTTP ${res.status}`)
+      }
+
+      const data: any = await res.json()
+      const formatted = data.results
+        .map((r: any, i: number) => {
+          const date = r.publishedAt ? ` · ${r.publishedAt}` : ''
+          return `${i + 1}. **${r.title}** (${r.source}${date})\n   ${r.url}\n   ${r.snippet}`
+        })
+        .join('\n\n')
+
+      return {
+        content: [{
+          type: 'text',
+          text: [
+            `📰 News results for: "${query}"`,
+            `💰 Paid: ${data.paidAmount} ${data.currency} on ${data.network}`,
+            `⚡ Latency: ${data.latencyMs}ms`,
+            `📊 ${data.count} results\n`,
+            formatted,
+          ].join('\n'),
+        }],
+      }
+    } catch (err: any) {
+      return { content: [{ type: 'text', text: `News search failed: ${err.message}` }], isError: true }
     }
   }
 

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -54,6 +54,20 @@ Use for current events, documentation, research, or anything needing up-to-date 
       },
     },
     {
+      name: 'image_search',
+      description: `Search the web for images via StellarSearch. Automatically pays ${AMOUNT_USDC} USDC on Stellar (x402 protocol).
+Returns image URLs, titles, and source domains via the Serper.dev images API.
+Use for visual references, photos, diagrams, or anything where you need image results.`,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Image search query' },
+          count: { type: 'number', description: 'Results count (1–10, default 5)', default: 5 },
+        },
+        required: ['query'],
+      },
+    },
+    {
       name: 'ai_summarize',
       description: 'Use Groq (Llama 3) to summarise or analyse text. Free — no payment required.',
       inputSchema: {
@@ -127,6 +141,43 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
     } catch (err: any) {
       return { content: [{ type: 'text', text: `Search failed: ${err.message}` }], isError: true }
+    }
+  }
+
+  // ── image_search ──────────────────────────────────────────────────────
+  if (name === 'image_search') {
+    const { query, count = 5 } = args as { query: string; count?: number }
+
+    try {
+      const safeCount = Math.min(Math.max(parseInt(String(count)) || 5, 1), 10)
+      const params = new URLSearchParams({ q: query, count: String(safeCount) })
+
+      const res = await fetch(`${SERVER_URL}/images?${params}`)
+
+      if (!res.ok) {
+        const e: any = await res.json().catch(() => ({}))
+        throw new Error(e.error || `HTTP ${res.status}`)
+      }
+
+      const data: any = await res.json()
+      const formatted = data.results
+        .map((r: any, i: number) => `${i + 1}. **${r.title}**\n   Image: ${r.imageUrl}\n   Source: ${r.sourceUrl} (${r.source})`)
+        .join('\n\n')
+
+      return {
+        content: [{
+          type: 'text',
+          text: [
+            `🖼️  Image results for: "${query}"`,
+            `💰 Paid: ${data.paidAmount} ${data.currency} on ${data.network}`,
+            `⚡ Latency: ${data.latencyMs}ms`,
+            `📊 ${data.count} results\n`,
+            formatted,
+          ].join('\n'),
+        }],
+      }
+    } catch (err: any) {
+      return { content: [{ type: 'text', text: `Image search failed: ${err.message}` }], isError: true }
     }
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -77,16 +77,22 @@ app.use(express.json())
 // ─── x402 payment guard on /search ───────────────────────────────────────
 // paymentMiddlewareFromConfig is the recommended API per official Stellar docs.
 // It uses the Coinbase public facilitator (no API key needed for testnet).
+const x402Accepts = [{
+  scheme:  'exact',
+  price:   parseFloat(AMOUNT_USDC),
+  amount:  AMOUNT_STROOPS,
+  network: NETWORK,
+  payTo:   RECEIVING_ADDRESS,
+}]
+
 const x402Routes = {
   'GET /search': {
-    accepts: [{
-      scheme:  'exact',
-      price:   parseFloat(AMOUNT_USDC),
-      amount:  AMOUNT_STROOPS,
-      network: NETWORK,
-      payTo:   RECEIVING_ADDRESS,
-    }],
+    accepts: x402Accepts,
     description: `StellarSearch: pay-per-query web search — ${AMOUNT_USDC} USDC on Stellar`,
+  },
+  'GET /images': {
+    accepts: x402Accepts,
+    description: `StellarSearch: pay-per-query image search — ${AMOUNT_USDC} USDC on Stellar`,
   },
 }
 
@@ -98,27 +104,34 @@ app.use(paymentMiddlewareFromConfig(x402Routes, facilitatorClient, schemes))
 
 const MAX_QUERY_LENGTH = 256
 
+// Validate and sanitize the user-supplied `q` parameter. Returns either the
+// cleaned string or a 400 response body to send back. Centralised so /search
+// and /images share the same rules.
+function validateQuery(
+  q: unknown,
+): { ok: true; cleanQ: string } | { ok: false; error: string } {
+  if (typeof q !== 'string' || !q.trim()) {
+    return { ok: false, error: 'Missing required parameter: q' }
+  }
+  if (q.length > MAX_QUERY_LENGTH) {
+    return { ok: false, error: `Query too long. Maximum ${MAX_QUERY_LENGTH} characters.` }
+  }
+  // Strip null bytes and ASCII control characters (C0 + DEL) to prevent
+  // log injection and odd Serper behavior.
+  const cleanQ = q.replace(/[\x00-\x1F\x7F]/g, '').trim()
+  if (!cleanQ) {
+    return { ok: false, error: 'Query contains no valid characters.' }
+  }
+  return { ok: true, cleanQ }
+}
+
 // ─── GET /search ──────────────────────────────────────────────────────────
 app.get('/search', async (req: Request, res: Response) => {
   const { q, count = '5', freshness } = req.query as Record<string, string>
 
-  if (typeof q !== 'string' || !q.trim()) {
-    return res.status(400).json({ error: 'Missing required parameter: q' })
-  }
-
-  if (q.length > MAX_QUERY_LENGTH) {
-    return res.status(400).json({
-      error: `Query too long. Maximum ${MAX_QUERY_LENGTH} characters.`,
-    })
-  }
-
-  // Strip null bytes and ASCII control characters (C0 + DEL) to prevent
-  // log injection and odd Serper behavior.
-  const cleanQ = q.replace(/[\x00-\x1F\x7F]/g, '').trim()
-
-  if (!cleanQ) {
-    return res.status(400).json({ error: 'Query contains no valid characters.' })
-  }
+  const v = validateQuery(q)
+  if (!v.ok) return res.status(400).json({ error: v.error })
+  const cleanQ = v.cleanQ
 
   const t0 = Date.now()
 
@@ -221,6 +234,72 @@ app.get('/search', async (req: Request, res: Response) => {
   }
 })
 
+// ─── GET /images ──────────────────────────────────────────────────────────
+app.get('/images', async (req: Request, res: Response) => {
+  const { q, count = '10' } = req.query as Record<string, string>
+
+  const v = validateQuery(q)
+  if (!v.ok) return res.status(400).json({ error: v.error })
+  const cleanQ = v.cleanQ
+
+  const t0 = Date.now()
+
+  try {
+    const serperRes = await fetch('https://google.serper.dev/images', {
+      method: 'POST',
+      headers: {
+        'X-API-KEY': SERPER_API_KEY,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        q: cleanQ,
+        num: Math.min(parseInt(count) || 10, 10),
+      }),
+    })
+
+    if (!serperRes.ok) {
+      const err = await serperRes.text()
+      console.error('[serper images]', serperRes.status, err)
+      return res.status(502).json({ error: `Serper.dev API error: ${serperRes.status}` })
+    }
+
+    const data = await serperRes.json()
+    const latencyMs = Date.now() - t0
+
+    stats.totalQueries++
+    stats.totalUsdcSettled += parseFloat(AMOUNT_USDC)
+    stats.latencies.push(latencyMs)
+    if (stats.latencies.length > 200) stats.latencies.shift()
+
+    const results = (data.images || []).map((r: any, i: number) => ({
+      id: String(i + 1),
+      title: r.title || 'No title',
+      imageUrl: r.imageUrl,
+      thumbnailUrl: r.thumbnailUrl || r.imageUrl,
+      sourceUrl: r.link,
+      source: (() => { try { return new URL(r.link).hostname.replace('www.', '') } catch { return r.link } })(),
+      width: r.imageWidth,
+      height: r.imageHeight,
+    }))
+
+    const txHash = (req.headers['x-payment-response'] as string) || null
+
+    return res.json({
+      query: cleanQ,
+      results,
+      count: results.length,
+      network: NETWORK,
+      paidAmount: AMOUNT_USDC,
+      currency: 'USDC',
+      txHash,
+      latencyMs,
+    })
+  } catch (err: any) {
+    console.error('[images error]', err.message)
+    return res.status(500).json({ error: 'Image search failed. Check server logs.' })
+  }
+})
+
 // ─── POST /ai/chat ────────────────────────────────────────────────────────
 app.post('/ai/chat', async (req: Request, res: Response) => {
   const { messages } = req.body as {
@@ -287,6 +366,7 @@ app.get('/', (_req: Request, res: Response) => {
     description: 'Pay-per-query web search for AI agents via x402 on Stellar',
     endpoints: {
       'GET /search?q=<query>': '0.001 USDC via x402',
+      'GET /images?q=<query>': '0.001 USDC via x402 — image results',
       'POST /ai/chat':         'Groq AI — free',
       'GET /health':           'Live server stats',
     },

--- a/server/index.ts
+++ b/server/index.ts
@@ -96,19 +96,35 @@ const schemes = [{ network: NETWORK, server: new ExactStellarScheme() }]
 // Apply middleware to all routes, not just /search
 app.use(paymentMiddlewareFromConfig(x402Routes, facilitatorClient, schemes))
 
+const MAX_QUERY_LENGTH = 256
+
 // ─── GET /search ──────────────────────────────────────────────────────────
 app.get('/search', async (req: Request, res: Response) => {
   const { q, count = '5', freshness } = req.query as Record<string, string>
 
-  if (!q?.trim()) {
+  if (typeof q !== 'string' || !q.trim()) {
     return res.status(400).json({ error: 'Missing required parameter: q' })
+  }
+
+  if (q.length > MAX_QUERY_LENGTH) {
+    return res.status(400).json({
+      error: `Query too long. Maximum ${MAX_QUERY_LENGTH} characters.`,
+    })
+  }
+
+  // Strip null bytes and ASCII control characters (C0 + DEL) to prevent
+  // log injection and odd Serper behavior.
+  const cleanQ = q.replace(/[\x00-\x1F\x7F]/g, '').trim()
+
+  if (!cleanQ) {
+    return res.status(400).json({ error: 'Query contains no valid characters.' })
   }
 
   const t0 = Date.now()
 
   try {
     const requestBody: any = {
-      q: q.trim(),
+      q: cleanQ,
       num: Math.min(parseInt(count) || 5, 20),
     }
 
@@ -174,7 +190,7 @@ app.get('/search', async (req: Request, res: Response) => {
             },
             {
               role: 'user',
-              content: `Query: "${q.trim()}"\nTop results: ${topSnippets}`,
+              content: `Query: "${cleanQ}"\nTop results: ${topSnippets}`,
             },
           ],
           max_tokens: 120,
@@ -189,7 +205,7 @@ app.get('/search', async (req: Request, res: Response) => {
     }
 
     return res.json({
-      query: q.trim(),
+      query: cleanQ,
       results,
       count: results.length,
       network: NETWORK,

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,6 +94,10 @@ const x402Routes = {
     accepts: x402Accepts,
     description: `StellarSearch: pay-per-query image search — ${AMOUNT_USDC} USDC on Stellar`,
   },
+  'GET /news': {
+    accepts: x402Accepts,
+    description: `StellarSearch: pay-per-query news search — ${AMOUNT_USDC} USDC on Stellar`,
+  },
 }
 
 const facilitatorClient = new HTTPFacilitatorClient({ url: FACILITATOR_URL })
@@ -300,6 +304,84 @@ app.get('/images', async (req: Request, res: Response) => {
   }
 })
 
+// ─── GET /news ────────────────────────────────────────────────────────────
+app.get('/news', async (req: Request, res: Response) => {
+  const { q, count = '10', freshness } = req.query as Record<string, string>
+
+  const v = validateQuery(q)
+  if (!v.ok) return res.status(400).json({ error: v.error })
+  const cleanQ = v.cleanQ
+
+  const t0 = Date.now()
+
+  try {
+    const requestBody: any = {
+      q: cleanQ,
+      num: Math.min(parseInt(count) || 10, 20),
+    }
+
+    if (freshness) {
+      const dateFilters: Record<string, string> = {
+        'pd': 'qdr:d',
+        'pw': 'qdr:w',
+        'pm': 'qdr:m',
+      }
+      if (dateFilters[freshness]) {
+        requestBody.tbs = dateFilters[freshness]
+      }
+    }
+
+    const serperRes = await fetch('https://google.serper.dev/news', {
+      method: 'POST',
+      headers: {
+        'X-API-KEY': SERPER_API_KEY,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    })
+
+    if (!serperRes.ok) {
+      const err = await serperRes.text()
+      console.error('[serper news]', serperRes.status, err)
+      return res.status(502).json({ error: `Serper.dev API error: ${serperRes.status}` })
+    }
+
+    const data = await serperRes.json()
+    const latencyMs = Date.now() - t0
+
+    stats.totalQueries++
+    stats.totalUsdcSettled += parseFloat(AMOUNT_USDC)
+    stats.latencies.push(latencyMs)
+    if (stats.latencies.length > 200) stats.latencies.shift()
+
+    const results = (data.news || []).map((r: any, i: number) => ({
+      id: String(i + 1),
+      title: r.title || 'No title',
+      url: r.link,
+      snippet: r.snippet || '',
+      source: r.source || (() => { try { return new URL(r.link).hostname.replace('www.', '') } catch { return r.link } })(),
+      publishedAt: r.date || undefined,
+      imageUrl: r.imageUrl || undefined,
+    }))
+
+    const txHash = (req.headers['x-payment-response'] as string) || null
+
+    return res.json({
+      query: cleanQ,
+      results,
+      count: results.length,
+      network: NETWORK,
+      paidAmount: AMOUNT_USDC,
+      currency: 'USDC',
+      txHash,
+      latencyMs,
+    })
+  } catch (err: any) {
+    console.error('[news error]', err.message)
+    return res.status(500).json({ error: 'News search failed. Check server logs.' })
+  }
+})
+
 // ─── POST /ai/chat ────────────────────────────────────────────────────────
 app.post('/ai/chat', async (req: Request, res: Response) => {
   const { messages } = req.body as {
@@ -367,6 +449,7 @@ app.get('/', (_req: Request, res: Response) => {
     endpoints: {
       'GET /search?q=<query>': '0.001 USDC via x402',
       'GET /images?q=<query>': '0.001 USDC via x402 — image results',
+      'GET /news?q=<query>':   '0.001 USDC via x402 — news articles',
       'POST /ai/chat':         'Groq AI — free',
       'GET /health':           'Live server stats',
     },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,7 +8,7 @@ export { WalletPanel } from './wallet'
 export { SearchBar, SearchResults, SearchSuggestions, PaymentFlowVisualizer } from './search'
 
 // UI
-export { StatsGrid } from './ui'
+export { StatsGrid, ZeroBalanceBanner } from './ui'
 
 // AI
 export { GroqAssistant } from './ai'

--- a/src/components/ui/ZeroBalanceBanner.tsx
+++ b/src/components/ui/ZeroBalanceBanner.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Coins, ExternalLink, X } from 'lucide-react'
+import { IS_MAINNET } from '../../lib/stellar'
+
+interface Props {
+  connected: boolean
+  publicKey: string | null
+  usdcBalance: string
+}
+
+const FAUCET_URL = 'https://laboratory.stellar.org/#account-creator?network=test'
+const TRUSTLINE_GUIDE_URL =
+  'https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#trustlines'
+
+const dismissKey = (publicKey: string) => `zero-balance-banner-dismissed:${publicKey}`
+
+export function ZeroBalanceBanner({ connected, publicKey, usdcBalance }: Props) {
+  const [dismissed, setDismissed] = useState(false)
+
+  // Reset / restore dismissal state when the connected account changes.
+  useEffect(() => {
+    if (!publicKey) {
+      setDismissed(false)
+      return
+    }
+    setDismissed(sessionStorage.getItem(dismissKey(publicKey)) === '1')
+  }, [publicKey])
+
+  const isZeroBalance = parseFloat(usdcBalance || '0') === 0
+  const visible = connected && !IS_MAINNET && isZeroBalance && !dismissed
+
+  const onDismiss = () => {
+    if (publicKey) sessionStorage.setItem(dismissKey(publicKey), '1')
+    setDismissed(true)
+  }
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          className="relative flex items-start gap-3 p-4 pr-10 rounded-xl border border-neon-amber/25 bg-neon-amber/5"
+          style={{ boxShadow: '0 0 20px rgba(255,193,7,0.06)' }}
+          role="status"
+        >
+          <Coins className="w-4 h-4 mt-0.5 text-neon-amber flex-shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <p className="text-sm text-neon-amber/90 leading-relaxed">
+              You need testnet USDC to search.{' '}
+              <a
+                href={FAUCET_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2 hover:text-neon-amber transition-colors inline-flex items-center gap-1"
+              >
+                Get free USDC <ExternalLink className="w-3 h-3" />
+              </a>
+            </p>
+            <p className="text-xs text-white/45">
+              New to Stellar?{' '}
+              <a
+                href={TRUSTLINE_GUIDE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-neon-cyan/80 hover:text-neon-cyan transition-colors inline-flex items-center gap-1"
+              >
+                USDC trustline setup guide <ExternalLink className="w-3 h-3" />
+              </a>
+            </p>
+          </div>
+          <button
+            onClick={onDismiss}
+            aria-label="Dismiss zero-balance notice"
+            className="absolute top-3 right-3 p-1 rounded text-white/30 hover:text-white/70 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
 export { StatsGrid } from './StatsGrid'
+export { ZeroBalanceBanner } from './ZeroBalanceBanner'

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -6,6 +6,7 @@ import {
   SearchSuggestions,
   PaymentFlowVisualizer,
   StatsGrid,
+  ZeroBalanceBanner,
 } from '../components'
 import { useSearch } from '../hooks/useSearch'
 import type { WalletState } from '../hooks/useFreighterWallet'
@@ -86,6 +87,12 @@ export function SearchPage({ wallet, onConnectWallet }: Props) {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <ZeroBalanceBanner
+        connected={wallet.connected}
+        publicKey={wallet.publicKey}
+        usdcBalance={wallet.usdcBalance}
+      />
 
       <SearchBar
         onSearch={handleSearch}


### PR DESCRIPTION
Bundles four Stellar Wave Program issues I was assigned. Each is committed separately so they're easy to review in isolation.

## Summary

- **#44 — Validate and sanitize the `q` parameter (security)**
  `server/index.ts`: factored a `validateQuery()` helper used by every paid route. Rejects > 256 chars with 400, strips null bytes and ASCII control chars (`\x00-\x1F` + `\x7F`), rejects with 400 if sanitisation leaves the query empty. Sanitised value is what gets forwarded to Serper, Groq, and reflected in the response.

- **#49 — Zero-USDC-balance banner on testnet (UX)**
  New `ZeroBalanceBanner` component wired into `SearchPage`. Renders only when wallet is connected, on testnet, and USDC balance parses to 0. Links to the Stellar Lab faucet plus the USDC trustline setup guide (new tab). Dismissible per wallet for the current session via `sessionStorage`.

- **#52 — `image_search` MCP tool (feature)**
  New `GET /images` x402-gated endpoint forwarding to `google.serper.dev/images`. New `image_search` MCP tool with `query` + `count` (1-10, default 5). Returns image URLs, titles, source domains.

- **#53 — `news_search` MCP tool (feature)**
  New `GET /news` x402-gated endpoint forwarding to `google.serper.dev/news` with the existing `pd`/`pw`/`pm` freshness filters. New `news_search` MCP tool with `query`, `count` (1-20, default 10), `freshness`. Output formats each article as title, source, date, URL, snippet.

Closes #44
Closes #49
Closes #52
Closes #53

## Test plan

- [x] Type check clean for `tsconfig.json` (frontend); no new errors on `tsconfig.server.json`
- [x] `/images` and `/news` return HTTP 402 without x402 payment (gating verified)
- [x] MCP `tools/list` exposes `image_search` and `news_search` with the documented input schemas
- [x] 11/11 validation cases pass for `q` (rejects > 256 chars, strips null bytes + control chars, allows unicode, etc.)
- [x] Vite dev server compiles and serves `ZeroBalanceBanner.tsx`
- [ ] Manual: connect Freighter on testnet with 0 USDC and confirm banner appears + dismissal sticks for the session
- [ ] Manual: pay via x402 and confirm `image_search` / `news_search` return formatted results end-to-end