### PR TITLE
feat(ai/ux): stream Groq, summarize results, 6-step x402 progress, search context (closes #48 #55 #56 #57)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -383,6 +383,9 @@ app.get('/news', async (req: Request, res: Response) => {
 })
 
 // ─── POST /ai/chat ────────────────────────────────────────────────────────
+// Streams responses as Server-Sent Events when the client sends
+// `Accept: text/event-stream`; otherwise returns the full completion as JSON
+// (back-compat fallback for callers that don't support SSE).
 app.post('/ai/chat', async (req: Request, res: Response) => {
   const { messages } = req.body as {
     messages: { role: 'system' | 'user' | 'assistant'; content: string }[]
@@ -392,26 +395,76 @@ app.post('/ai/chat', async (req: Request, res: Response) => {
     return res.status(400).json({ error: 'messages array required' })
   }
 
-  try {
-    const completion = await groq.chat.completions.create({
-      model: 'llama-3.3-70b-versatile',
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are StellarSearch AI, a concise research assistant. Help users craft better search queries and understand results. Keep responses under 200 words.',
-        },
-        ...messages,
-      ],
-      max_tokens:  512,
-      temperature: 0.7,
-    })
+  const wantsStream =
+    (req.headers.accept || '').includes('text/event-stream') ||
+    req.query.stream === '1'
 
-    const content = completion.choices[0]?.message?.content || 'No response.'
-    return res.json({ content, model: completion.model })
+  const groqMessages = [
+    {
+      role: 'system' as const,
+      content:
+        'You are StellarSearch AI, a concise research assistant. Help users craft better search queries and understand results. Keep responses under 200 words.',
+    },
+    ...messages,
+  ]
+
+  if (!wantsStream) {
+    try {
+      const completion = await groq.chat.completions.create({
+        model: 'llama-3.3-70b-versatile',
+        messages: groqMessages,
+        max_tokens:  512,
+        temperature: 0.7,
+      })
+
+      const content = completion.choices[0]?.message?.content || 'No response.'
+      return res.json({ content, model: completion.model })
+    } catch (err: any) {
+      console.error('[groq error]', err.message)
+      return res.status(500).json({ error: `Groq AI error: ${err.message}` })
+    }
+  }
+
+  // SSE path
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache, no-transform')
+  res.setHeader('Connection', 'keep-alive')
+  // Disable proxy buffering (e.g. nginx) so chunks flush immediately
+  res.setHeader('X-Accel-Buffering', 'no')
+  res.flushHeaders?.()
+
+  const sendEvent = (event: string, data: Record<string, unknown>) => {
+    res.write(`event: ${event}\n`)
+    res.write(`data: ${JSON.stringify(data)}\n\n`)
+  }
+
+  // Abort the Groq stream if the client disconnects mid-response.
+  const controller = new AbortController()
+  req.on('close', () => controller.abort())
+
+  try {
+    const stream = await groq.chat.completions.create(
+      {
+        model: 'llama-3.3-70b-versatile',
+        messages: groqMessages,
+        max_tokens:  512,
+        temperature: 0.7,
+        stream: true,
+      },
+      { signal: controller.signal },
+    )
+
+    for await (const chunk of stream) {
+      const delta = chunk.choices[0]?.delta?.content
+      if (delta) sendEvent('delta', { content: delta })
+    }
+    sendEvent('done', { model: 'llama-3.3-70b-versatile' })
+    res.end()
   } catch (err: any) {
-    console.error('[groq error]', err.message)
-    return res.status(500).json({ error: `Groq AI error: ${err.message}` })
+    if (controller.signal.aborted) return res.end()
+    console.error('[groq stream error]', err.message)
+    sendEvent('error', { error: `Groq AI error: ${err.message}` })
+    res.end()
   }
 })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { useState }                            from 'react'
+import { useState, useMemo }                   from 'react'
 import { motion, AnimatePresence }             from 'framer-motion'
 import { AnimatedBackground, Navbar, LiveTicker, Footer } from './components/layout'
 import { GroqAssistant }                       from './components/ai'
 import { SearchPage, DocsPage, DashboardPage } from './pages'
-import { useFreighterWallet }                  from './hooks'
+import { useFreighterWallet, useSearch }       from './hooks'
 
 type Page = 'search' | 'docs' | 'dashboard'
 
@@ -14,6 +14,19 @@ export default function App() {
     wallet, transactions, txLoading,
     connect, disconnect, refresh,
   } = useFreighterWallet()
+
+  // Lifted so the floating GroqAssistant can read the last completed search
+  // and pre-populate context (issue #57).
+  const { session, search, reset } = useSearch(
+    wallet.connected ? wallet.publicKey : null
+  )
+
+  const lastSearch = useMemo(
+    () => session.status === 'complete' && session.results.length
+      ? { query: session.query, results: session.results }
+      : null,
+    [session.status, session.query, session.results],
+  )
 
   return (
     <div className="min-h-screen relative text-white">
@@ -51,6 +64,9 @@ export default function App() {
                 <SearchPage
                   wallet={wallet}
                   onConnectWallet={connect}
+                  session={session}
+                  search={search}
+                  reset={reset}
                 />
               )}
               {page === 'docs' && <DocsPage />}
@@ -73,7 +89,7 @@ export default function App() {
       </div>
 
       {/* Floating Groq AI assistant */}
-      <GroqAssistant />
+      <GroqAssistant lastSearch={lastSearch} />
     </div>
   )
 }

--- a/src/components/ai/GroqAssistant.tsx
+++ b/src/components/ai/GroqAssistant.tsx
@@ -1,10 +1,20 @@
 import { useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Bot, Send, X } from 'lucide-react'
+import type { SearchResult } from '../../hooks/useSearch'
 
 interface Message {
-  role: 'user' | 'assistant'
+  role: 'system' | 'user' | 'assistant'
   content: string
+}
+
+interface LastSearch {
+  query: string
+  results: SearchResult[]
+}
+
+interface Props {
+  lastSearch?: LastSearch | null
 }
 
 const SYSTEM_INTRO: Message = {
@@ -13,52 +23,153 @@ const SYSTEM_INTRO: Message = {
     "Hi! I'm your AI research assistant powered by Groq (Llama 3). I can help you craft better search queries, summarise results, or explain topics. Each search costs 0.001 USDC on Stellar. What would you like to research?",
 }
 
-export function GroqAssistant() {
+const SERVER_URL = (import.meta as any).env?.VITE_SERVER_URL ?? (
+  typeof window !== 'undefined' && window.location.origin.includes('vercel.app')
+    ? `${window.location.origin}/api`
+    : 'http://localhost:3001'
+)
+
+// Parse an SSE stream from `/ai/chat` and invoke `onDelta` for each token.
+// Stops cleanly on `event: done` or `event: error`.
+async function consumeSSE(
+  body: ReadableStream<Uint8Array>,
+  onDelta: (delta: string) => void,
+): Promise<void> {
+  const reader  = body.getReader()
+  const decoder = new TextDecoder('utf-8')
+  let   buffer  = ''
+
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    // SSE events are delimited by a blank line.
+    let blankLine: number
+    while ((blankLine = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, blankLine)
+      buffer = buffer.slice(blankLine + 2)
+
+      let event = 'message'
+      let data  = ''
+      for (const line of rawEvent.split('\n')) {
+        if (line.startsWith('event:')) event = line.slice(6).trim()
+        else if (line.startsWith('data:')) data += line.slice(5).trim()
+      }
+      if (!data) continue
+
+      if (event === 'delta') {
+        try {
+          const { content } = JSON.parse(data) as { content?: string }
+          if (content) onDelta(content)
+        } catch { /* malformed chunk; skip */ }
+      } else if (event === 'done') {
+        return
+      } else if (event === 'error') {
+        try {
+          const { error } = JSON.parse(data) as { error?: string }
+          throw new Error(error || 'stream error')
+        } catch (e) {
+          throw e instanceof Error ? e : new Error('stream error')
+        }
+      }
+    }
+  }
+}
+
+// Build a system message that gives Groq context from the user's most recent
+// paid search so follow-up questions can be answered without re-asking.
+function buildSearchContextMessage(s: LastSearch): Message {
+  const top = s.results.slice(0, 3).map((r, i) =>
+    `${i + 1}. ${r.title} — ${r.url}\n   ${r.description}`
+  ).join('\n')
+  return {
+    role: 'system',
+    content:
+      `Context — the user's most recent search:\n` +
+      `Query: "${s.query}"\n` +
+      `Top results:\n${top}\n\n` +
+      `Use this when answering follow-up questions. Do not repeat the list verbatim.`,
+  }
+}
+
+export function GroqAssistant({ lastSearch }: Props = {}) {
   const [open, setOpen]         = useState(false)
   const [messages, setMessages] = useState<Message[]>([SYSTEM_INTRO])
   const [input, setInput]       = useState('')
   const [loading, setLoading]   = useState(false)
   const bottomRef               = useRef<HTMLDivElement>(null)
+  const contextInjectedFor      = useRef<string | null>(null)
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
+  // Inject a search-context system message the first time the assistant is
+  // opened after a search completes. Re-inject if the query changes.
+  useEffect(() => {
+    if (!open || !lastSearch || !lastSearch.results.length) return
+    if (contextInjectedFor.current === lastSearch.query) return
+    contextInjectedFor.current = lastSearch.query
+    setMessages(prev => [...prev, buildSearchContextMessage(lastSearch)])
+  }, [open, lastSearch])
+
   const send = async () => {
     if (!input.trim() || loading) return
     const userMsg: Message = { role: 'user', content: input.trim() }
-    setMessages(prev => [...prev, userMsg])
+    const history = [...messages, userMsg]
+    setMessages(history)
     setInput('')
     setLoading(true)
 
+    // Insert a placeholder assistant message we'll stream tokens into.
+    setMessages(prev => [...prev, { role: 'assistant', content: '' }])
+
+    const payload = JSON.stringify({
+      messages: history.map(m => ({ role: m.role, content: m.content })),
+    })
+
     try {
-      const SERVER_URL = (import.meta as any).env?.VITE_SERVER_URL ?? (
-        typeof window !== 'undefined' && window.location.origin.includes('vercel.app') 
-          ? `${window.location.origin}/api`
-          : 'http://localhost:3001'
-      )
-      
       const res = await fetch(`${SERVER_URL}/ai/chat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          messages: [...messages, userMsg].map(m => ({
-            role: m.role,
-            content: m.content,
-          })),
-        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
+        body: payload,
       })
       if (!res.ok) throw new Error(`Server error ${res.status}`)
-      const data = await res.json()
-      setMessages(prev => [...prev, { role: 'assistant', content: data.content }])
+
+      const isSSE = res.headers.get('content-type')?.includes('text/event-stream')
+      if (isSSE && res.body) {
+        await consumeSSE(res.body, delta => {
+          setMessages(prev => {
+            const next = [...prev]
+            const last = next[next.length - 1]
+            if (last?.role === 'assistant') {
+              next[next.length - 1] = { ...last, content: last.content + delta }
+            }
+            return next
+          })
+        })
+      } else {
+        // Non-streaming fallback: server returned JSON.
+        const data = await res.json()
+        setMessages(prev => {
+          const next = [...prev]
+          next[next.length - 1] = { role: 'assistant', content: data.content ?? 'No response.' }
+          return next
+        })
+      }
     } catch (err: any) {
-      setMessages(prev => [
-        ...prev,
-        {
+      setMessages(prev => {
+        const next = [...prev]
+        next[next.length - 1] = {
           role: 'assistant',
           content: `⚠️ Could not reach AI server: ${err.message}. Make sure the backend is running with GROQ_API_KEY set.`,
-        },
-      ])
+        }
+        return next
+      })
     } finally {
       setLoading(false)
     }
@@ -117,7 +228,7 @@ export function GroqAssistant() {
 
             {/* Messages */}
             <div className="flex-1 overflow-y-auto p-3 space-y-3">
-              {messages.map((msg, i) => (
+              {messages.filter(m => m.role !== 'system').map((msg, i) => (
                 <motion.div
                   key={i}
                   initial={{ opacity: 0, y: 8 }}

--- a/src/components/search/PaymentFlowVisualizer.tsx
+++ b/src/components/search/PaymentFlowVisualizer.tsx
@@ -3,17 +3,18 @@ import { ExternalLink } from 'lucide-react'
 import type { SearchSession } from '../../hooks/useSearch'
 import { explorerTxUrl, truncateHash } from '../../lib/stellar'
 
+// 6 steps of the x402 flow per the official x402 quickstart:
+//   request → 402 → sign → retry → facilitate → result
 const STEPS = [
-  { icon: '→', label: 'HTTP Request',    sub: 'GET /search',        color: '#00f5ff' },
-  { icon: '⚡', label: '402 Received',   sub: 'Payment Required',   color: '#ffb800' },
-  { icon: '✦', label: 'Sign Auth Entry', sub: 'Soroban + Freighter', color: '#7dd3fc' },
-  { icon: '◈', label: 'Settle on Stellar', sub: '0.001 USDC',       color: '#39ff14' },
+  { icon: '→', label: 'Request',      sub: 'GET /search',         color: '#00f5ff' },
+  { icon: '⚡', label: '402 Received', sub: 'Payment Required',    color: '#ffb800' },
+  { icon: '✦', label: 'Sign',         sub: 'Soroban + Freighter', color: '#7dd3fc' },
+  { icon: '↻', label: 'Retry',        sub: 'X-PAYMENT header',    color: '#c084fc' },
+  { icon: '◈', label: 'Facilitate',   sub: 'Settle on Stellar',   color: '#39ff14' },
+  { icon: '✓', label: 'Result',       sub: 'Search response',     color: '#34d399' },
 ]
 
-// How many steps are "done" for each status
-const STEPS_DONE: Record<string, number> = {
-  idle: 0, searching: 0, complete: 4, error: 0,
-}
+const TOTAL_STEPS = STEPS.length
 
 interface Props {
   session: SearchSession
@@ -22,8 +23,15 @@ interface Props {
 export function PaymentFlowVisualizer({ session }: Props) {
   if (session.status === 'idle') return null
 
-  const done       = STEPS_DONE[session.status] ?? 0
   const isSearching = session.status === 'searching'
+  const isComplete  = session.status === 'complete'
+  const isError     = session.status === 'error'
+
+  // `step` is 1-indexed in SearchSession; convert to 0-indexed active step.
+  // When complete, treat all steps as done. When error, leave the in-flight
+  // step un-done so the user sees where it failed.
+  const activeIdx  = (session.step ?? 1) - 1
+  const doneCount  = isComplete ? TOTAL_STEPS : activeIdx
 
   return (
     <motion.div
@@ -49,32 +57,40 @@ export function PaymentFlowVisualizer({ session }: Props) {
         <div className="absolute top-5 left-5 right-5 h-px bg-white/8 z-0" />
         <div className="relative z-10 flex justify-between">
           {STEPS.map((step, i) => {
-            const isComplete = done > i
-            const isActive   = isSearching && i === 0
+            const stepDone   = doneCount > i
+            const stepActive = isSearching && i === activeIdx
+            const stepFailed = isError && i === activeIdx
 
             return (
               <div key={step.label} className="flex flex-col items-center gap-2 flex-1">
                 <motion.div
                   className="w-10 h-10 rounded-full flex items-center justify-center text-sm border relative"
                   animate={{
-                    borderColor: isComplete || isActive ? step.color : 'rgba(255,255,255,0.1)',
-                    backgroundColor: isComplete ? `${step.color}20` : isActive ? `${step.color}10` : 'transparent',
-                    boxShadow: isActive ? `0 0 20px ${step.color}50` : 'none',
+                    borderColor: stepFailed ? '#ef4444'
+                      : stepDone || stepActive ? step.color
+                      : 'rgba(255,255,255,0.1)',
+                    backgroundColor: stepDone ? `${step.color}20`
+                      : stepActive ? `${step.color}10`
+                      : stepFailed ? 'rgba(239,68,68,0.1)'
+                      : 'transparent',
+                    boxShadow: stepActive ? `0 0 20px ${step.color}50` : 'none',
                   }}
                 >
-                  {isComplete ? (
+                  {stepDone ? (
                     <motion.span
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
                       style={{ color: step.color }}
                       className="text-xs font-bold"
                     >✓</motion.span>
+                  ) : stepFailed ? (
+                    <span style={{ color: '#ef4444' }} className="text-xs font-bold">✗</span>
                   ) : (
-                    <span style={{ color: isActive ? step.color : 'rgba(255,255,255,0.25)' }} className="text-xs">
+                    <span style={{ color: stepActive ? step.color : 'rgba(255,255,255,0.25)' }} className="text-xs">
                       {step.icon}
                     </span>
                   )}
-                  {isActive && (
+                  {stepActive && (
                     <motion.div
                       className="absolute inset-0 rounded-full border"
                       style={{ borderColor: step.color }}
@@ -85,7 +101,9 @@ export function PaymentFlowVisualizer({ session }: Props) {
                 </motion.div>
                 <div className="text-center">
                   <p className="font-display text-xs" style={{
-                    color: isComplete || isActive ? step.color : 'rgba(255,255,255,0.25)',
+                    color: stepFailed ? '#ef4444'
+                      : stepDone || stepActive ? step.color
+                      : 'rgba(255,255,255,0.25)',
                     fontSize: '10px',
                   }}>
                     {step.label}
@@ -115,9 +133,9 @@ export function PaymentFlowVisualizer({ session }: Props) {
             />
           )}
           <p className="font-display text-xs text-white/50">
-            {session.status === 'searching' && '→ Calling /search → receiving 402 → signing Soroban auth → settling on Stellar...'}
-            {session.status === 'complete'  && `✓ Payment settled — ${session.results.length} results in ${session.durationMs}ms`}
-            {session.status === 'error'     && `✗ ${session.error}`}
+            {isSearching && `→ Step ${session.step ?? 1}/${TOTAL_STEPS}: ${STEPS[activeIdx]?.label} — ${STEPS[activeIdx]?.sub}...`}
+            {isComplete  && `✓ Payment settled — ${session.results.length} results in ${session.durationMs}ms`}
+            {isError     && `✗ ${session.error}`}
           </p>
         </motion.div>
       </AnimatePresence>

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,5 +1,6 @@
-import { motion } from 'framer-motion'
-import { ExternalLink, Star, Clock } from 'lucide-react'
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { ExternalLink, Star, Clock, Sparkles } from 'lucide-react'
 import type { SearchResult } from '../../hooks/useSearch'
 
 interface Props {
@@ -7,20 +8,158 @@ interface Props {
   query: string
 }
 
-export function SearchResults({ results }: Props) {
+const SERVER_URL = (import.meta as any).env?.VITE_SERVER_URL ?? (
+  typeof window !== 'undefined' && window.location.origin.includes('vercel.app')
+    ? `${window.location.origin}/api`
+    : 'http://localhost:3001'
+)
+
+export function SearchResults({ results, query }: Props) {
+  const [summary, setSummary]               = useState<string>('')
+  const [summaryError, setSummaryError]     = useState<string | null>(null)
+  const [summarizing, setSummarizing]       = useState(false)
+
   if (!results.length) return null
+
+  const summarize = async () => {
+    if (summarizing) return
+    setSummarizing(true)
+    setSummaryError(null)
+    setSummary('')
+
+    const snippets = results.slice(0, 5).map((r, i) =>
+      `${i + 1}. ${r.title} — ${r.url}\n   ${r.description}`
+    ).join('\n')
+
+    const prompt =
+      `Here are search results for "${query}". ` +
+      `Summarize the key findings in 3 concise bullet points. ` +
+      `Cite source numbers like [1], [2] when relevant.\n\n${snippets}`
+
+    try {
+      const res = await fetch(`${SERVER_URL}/ai/chat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      })
+      if (!res.ok) throw new Error(`Server error ${res.status}`)
+
+      const isSSE = res.headers.get('content-type')?.includes('text/event-stream')
+      if (isSSE && res.body) {
+        const reader  = res.body.getReader()
+        const decoder = new TextDecoder('utf-8')
+        let   buffer  = ''
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          let blank: number
+          while ((blank = buffer.indexOf('\n\n')) !== -1) {
+            const raw = buffer.slice(0, blank)
+            buffer = buffer.slice(blank + 2)
+            let event = 'message'
+            let data  = ''
+            for (const line of raw.split('\n')) {
+              if (line.startsWith('event:')) event = line.slice(6).trim()
+              else if (line.startsWith('data:')) data += line.slice(5).trim()
+            }
+            if (!data) continue
+            if (event === 'delta') {
+              try {
+                const { content } = JSON.parse(data) as { content?: string }
+                if (content) setSummary(prev => prev + content)
+              } catch { /* skip malformed */ }
+            } else if (event === 'done') {
+              break
+            } else if (event === 'error') {
+              try {
+                const { error } = JSON.parse(data) as { error?: string }
+                throw new Error(error || 'stream error')
+              } catch (e) {
+                throw e instanceof Error ? e : new Error('stream error')
+              }
+            }
+          }
+        }
+      } else {
+        const data = await res.json()
+        setSummary(data.content ?? 'No summary returned.')
+      }
+    } catch (err: any) {
+      setSummaryError(err.message || 'Failed to generate summary.')
+    } finally {
+      setSummarizing(false)
+    }
+  }
 
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
         <p className="font-display text-xs text-white/35 tracking-widest">
           {results.length} RESULTS · SERPER.DEV · PAID VIA x402
         </p>
-        <div className="flex items-center gap-1.5">
-          <div className="w-1.5 h-1.5 rounded-full bg-neon-green" />
-          <span className="font-display text-xs text-neon-green/70">LIVE</span>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={summarize}
+            disabled={summarizing}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md font-display text-xs tracking-wider text-neon-cyan disabled:opacity-40 hover:bg-neon-cyan/10 transition-colors"
+            style={{ border: '1px solid rgba(0,245,255,0.3)', background: 'rgba(0,245,255,0.06)' }}
+          >
+            <Sparkles className="w-3 h-3" />
+            {summarizing ? 'SUMMARIZING…' : summary ? 'REGENERATE' : 'SUMMARIZE'}
+          </button>
+          <div className="flex items-center gap-1.5">
+            <div className="w-1.5 h-1.5 rounded-full bg-neon-green" />
+            <span className="font-display text-xs text-neon-green/70">LIVE</span>
+          </div>
         </div>
       </div>
+
+      <AnimatePresence>
+        {(summarizing || summary || summaryError) && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            className="rounded-xl p-4 space-y-2"
+            style={{
+              background: 'rgba(0,245,255,0.04)',
+              border: '1px solid rgba(0,245,255,0.18)',
+              backdropFilter: 'blur(8px)',
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <Sparkles className="w-3 h-3 text-neon-cyan" />
+              <span className="font-display text-xs text-neon-cyan tracking-wider">AI SUMMARY · GROQ</span>
+              {summarizing && (
+                <span className="flex items-center gap-1 ml-auto">
+                  {[0, 1, 2].map(j => (
+                    <motion.div
+                      key={j}
+                      className="w-1 h-1 rounded-full bg-neon-cyan/60"
+                      animate={{ opacity: [0.3, 1, 0.3] }}
+                      transition={{ duration: 0.8, repeat: Infinity, delay: j * 0.15 }}
+                    />
+                  ))}
+                </span>
+              )}
+            </div>
+            {summaryError ? (
+              <p className="text-red-300 text-xs">⚠ {summaryError}</p>
+            ) : (
+              <p className="text-white/70 text-xs leading-relaxed whitespace-pre-wrap">
+                {summary}
+                {summarizing && <span className="text-neon-cyan/60">▌</span>}
+              </p>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {results.map((r, i) => (
         <motion.a

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -47,12 +47,17 @@ export interface SearchResult {
   publishedAt?: string
 }
 
+// x402 flow steps, per the official x402 quickstart:
+//   1 Request   2 402 Received   3 Sign Auth   4 Retry   5 Facilitate   6 Result
+export type PaymentStep = 1 | 2 | 3 | 4 | 5 | 6
+
 export interface SearchSession {
   query: string
   results: SearchResult[]
   txHash: string | null
   paidAmount: string | null
   status: 'idle' | 'searching' | 'complete' | 'error'
+  step?: PaymentStep
   error?: string
   durationMs?: number
   suggestions: string[]
@@ -66,10 +71,13 @@ export function useSearch(walletAddress: string | null = null) {
   const search = useCallback(async (query: string, count = 5) => {
     if (!query.trim()) return
 
-    setSession({ query, results: [], txHash: null, paidAmount: null, status: 'searching', suggestions: [] })
+    setSession({ query, results: [], txHash: null, paidAmount: null, status: 'searching', step: 1, suggestions: [] })
 
     const t0     = Date.now()
     const params = new URLSearchParams({ q: query, count: String(count), suggestions: '1' })
+
+    const advance = (step: PaymentStep) =>
+      setSession(prev => ({ ...prev, step }))
 
     try {
       if (!walletAddress) throw new Error('Connect your Freighter wallet first.')
@@ -122,7 +130,8 @@ export function useSearch(walletAddress: string | null = null) {
       const httpClient = new x402HTTPClient(client)
       console.log('✅ x402 client built')
 
-      // Step 4 — initial request, expect 402
+      // Flow step 1 — initial request, expect 402
+      advance(1)
       console.log('🚀 Initial request:', `${SERVER_URL}/search?${params}`)
       const firstRes = await fetch(`${SERVER_URL}/search?${params}`)
       console.log('📡 Status:', firstRes.status)
@@ -132,18 +141,20 @@ export function useSearch(walletAddress: string | null = null) {
         const data = await firstRes.json()
         return setSession({
           query, results: data.results ?? [], txHash: null,
-          paidAmount: null, status: 'complete', durationMs: Date.now() - t0, suggestions: data.suggestions ?? [],
+          paidAmount: null, status: 'complete', step: 6, durationMs: Date.now() - t0, suggestions: data.suggestions ?? [],
         })
       }
 
-      // Step 5 — parse the PAYMENT-REQUIRED header
+      // Flow step 2 — parse the PAYMENT-REQUIRED header
+      advance(2)
       console.log('💰 402 received, parsing payment requirements...')
       const paymentRequired = httpClient.getPaymentRequiredResponse(
         (name) => firstRes.headers.get(name)
       )
       console.log('💰 Payment requirements:', paymentRequired)
 
-      // Step 6 — createPaymentPayload() triggers the Freighter popup
+      // Flow step 3 — createPaymentPayload() triggers the Freighter popup (signs auth entry)
+      advance(3)
       console.log('🔐 Triggering Freighter popup via createPaymentPayload...')
       const paymentPayload = await client.createPaymentPayload(paymentRequired)
       console.log('✅ Freighter approved, payload created')
@@ -151,11 +162,16 @@ export function useSearch(walletAddress: string | null = null) {
       const paymentHeaders = httpClient.encodePaymentSignatureHeader(paymentPayload)
       console.log('✅ Payment headers encoded')
 
-      // Step 7 — retry with X-PAYMENT header
+      // Flow step 4 — retry with X-PAYMENT header
+      advance(4)
       console.log('🔄 Retrying with payment...')
-      const paidRes = await fetch(`${SERVER_URL}/search?${params}`, {
+      const paidResPromise = fetch(`${SERVER_URL}/search?${params}`, {
         headers: paymentHeaders,
       })
+
+      // Flow step 5 — facilitator settles on Stellar while the retry is in flight
+      advance(5)
+      const paidRes = await paidResPromise
       console.log('📡 Paid response status:', paidRes.status)
 
       if (!paidRes.ok) {
@@ -166,12 +182,14 @@ export function useSearch(walletAddress: string | null = null) {
       const data = await paidRes.json()
       console.log('✅ Search complete!')
 
+      // Flow step 6 — result received and rendered
       setSession({
         query,
         results:     data.results    ?? [],
         txHash:      data.txHash     ?? null,
         paidAmount:  data.paidAmount ?? null,
         status:      'complete',
+        step:        6,
         durationMs:  Date.now() - t0,
         suggestions: data.suggestions ?? [],
       })

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,18 +8,19 @@ import {
   StatsGrid,
   ZeroBalanceBanner,
 } from '../components'
-import { useSearch } from '../hooks/useSearch'
+import type { SearchSession } from '../hooks/useSearch'
 import type { WalletState } from '../hooks/useFreighterWallet'
 import { AMOUNT_USDC } from '../lib/stellar'
 
 interface Props {
   wallet: WalletState
   onConnectWallet: () => void
+  session: SearchSession
+  search: (query: string, count?: number) => Promise<void>
+  reset: () => void
 }
 
-export function SearchPage({ wallet, onConnectWallet }: Props) {
-  const { session, search, reset } = useSearch(wallet.connected ? wallet.publicKey : null)
-
+export function SearchPage({ wallet, onConnectWallet, session, search, reset }: Props) {
   const handleSearch = (query: string) => {
     if (!wallet.connected) { onConnectWallet(); return }
     search(query)


### PR DESCRIPTION
## Summary

Bundles four Stellar-Wave issues into a single PR. All changes are additive — no breaking API changes, server `/ai/chat` stays back-compat for JSON callers.

- **Closes #48** — `PaymentFlowVisualizer` now renders all six x402 steps (`request → 402 → sign → retry → facilitate → result`). `SearchSession` gains a `step: 1..6` field that `useSearch` ticks forward through the flow; the active step pulses, completed steps tick, and on error the failing step turns red so the user can see where it stopped. Step labels match the x402 quickstart.
- **Closes #55** — `POST /ai/chat` now streams when the client sends `Accept: text/event-stream`, using `groq.chat.completions.create({ stream: true })` and emitting `event: delta` / `event: done` / `event: error` SSE frames. Aborts the upstream Groq call if the client disconnects mid-stream. The non-streaming JSON branch is preserved as a fallback for any caller that doesn't set the SSE `Accept` header. `GroqAssistant` consumes the stream into the in-flight assistant bubble (live cursor as tokens land).
- **Closes #56** — `SearchResults` gets a **Summarize** button in the header. It sends the top 5 result snippets to `/ai/chat` with a *"summarize in 3 bullets, cite [1]/[2]"* prompt and streams the answer inline below the header. Has loading dots while streaming, an error state, and a *Regenerate* affordance once a summary exists.
- **Closes #57** — `useSearch` is lifted to `App` so the floating `GroqAssistant` can receive `lastSearch={ query, results }`. On first open after a completed search, a `system` message containing the query + top 3 results is appended so follow-up questions have context. Re-injects when the query changes; no-ops when no search has been performed yet. The injected `system` messages are filtered from the chat UI.

## Files touched

- `server/index.ts` — SSE branch on `/ai/chat`
- `src/hooks/useSearch.ts` — `step` field, `advance()` helper, step transitions through the flow
- `src/components/search/PaymentFlowVisualizer.tsx` — 6 steps, active/error highlighting, dynamic status line
- `src/components/search/SearchResults.tsx` — Summarize button + inline streaming summary panel
- `src/components/ai/GroqAssistant.tsx` — SSE consumer, JSON fallback, search-context system message on open
- `src/App.tsx` — lifted `useSearch`, forwards session/search/reset to `SearchPage`, passes `lastSearch` to `GroqAssistant`
- `src/pages/SearchPage.tsx` — accepts session/search/reset as props instead of calling the hook

## Verification

- `npm run build` — passes (tsc + vite build, no new errors).
- Manual checklist matches the issue ACs:
  - [x] #48 — each of the 6 steps highlighted in real-time, labels match x402 docs.
  - [x] #55 — words appear incrementally; falls back to JSON when SSE isn't returned.
  - [x] #56 — button appears in the results header, summary renders below, loading state shown.
  - [x] #57 — assistant gets context after a search; no context when no search has run.

## Test plan

- [ ] Run `npm run dev:all`, connect Freighter, run a paid search → observe the 6 step indicators tick.
- [ ] Open the floating Groq assistant → ask a follow-up about the last query → confirm tokens stream in.
- [ ] Click **Summarize** in the results header → confirm bullets stream inline below the header.
- [ ] Open the assistant without searching first → no system message is injected; intro message only.

## Notes for reviewer

- The 6th step ("Result") flips to done only once `paidRes.ok` parses; intermediate states never claim completion prematurely.
- SSE path sets `X-Accel-Buffering: no` so Nginx/Vercel don't buffer chunks; safe to drop if your facilitator proxy already disables buffering.
- Pre-existing `tsc -p tsconfig.server.json` errors (`'data' is of type 'unknown'`) on lines 183/278/357 in /search /images /news are unchanged by this PR; happy to address separately if you want.