### PR TITLE
feat: cache repeated searches for 60 seconds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,12 @@
         "express-rate-limit": "^8.6.2",
         "framer-motion": "^11.0.0",
         "groq-sdk": "^0.9.0",
+<<<<<<< HEAD
         "helmet": "^8.3.0",
         "i18next": "^26.4.0",
+=======
+        "lru-cache": "^11.5.2",
+>>>>>>> 91f06ea (feat: cache repeated searches with bounded TTL)
         "lucide-react": "^0.344.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -68,12 +72,21 @@
         "node": ">=18.0.0"
       }
     },
+<<<<<<< HEAD
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+=======
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT",
+      "peer": true
+>>>>>>> 91f06ea (feat: cache repeated searches with bounded TTL)
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.11.1",
@@ -232,6 +245,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -5088,6 +5111,7 @@
         "acorn": "^8"
       }
     },
+<<<<<<< HEAD
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -5097,6 +5121,14 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+=======
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT",
+      "peer": true
+>>>>>>> 91f06ea (feat: cache repeated searches with bounded TTL)
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -6771,6 +6803,81 @@
         "node": ">= 0.6"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT",
+      "peer": true
+    },
+>>>>>>> 91f06ea (feat: cache repeated searches with bounded TTL)
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -7931,6 +8038,7 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+<<<<<<< HEAD
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7950,6 +8058,10 @@
       },
       "engines": {
         "node": ">=8"
+=======
+      "bin": {
+        "jiti": "bin/jiti.js"
+>>>>>>> 91f06ea (feat: cache repeated searches with bounded TTL)
       }
     },
     "node_modules/jose": {
@@ -8489,13 +8601,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lucide-react": {
@@ -9082,15 +9193,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/path-to-regexp": {
@@ -10010,6 +10112,7 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+<<<<<<< HEAD
     "node_modules/sonner": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.8.tgz",
@@ -10026,6 +10129,8 @@
         }
       }
     },
+=======
+>>>>>>> 91f06ea (feat: cache repeated searches with bounded TTL)
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "groq-sdk": "^0.9.0",
     "helmet": "^8.3.0",
     "i18next": "^26.4.0",
+    "lru-cache": "^11.5.2",
     "lucide-react": "^0.344.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import Groq from 'groq-sdk'
 import { paymentMiddlewareFromConfig } from '@x402/express'
 import { ExactStellarScheme } from '@x402/stellar/exact/server'
 import { HTTPFacilitatorClient } from '@x402/core/server'
+import { LRUCache } from 'lru-cache'
 import logger from './logger'
 import crypto, { randomUUID } from 'crypto'
 import {
@@ -259,6 +260,9 @@ async function deliverWebhookWithRetry(job: SearchJob, maxAttempts = MAX_JOB_WEB
   console.error(`[webhook] exhausted retries for job ${job.id}`)
 }
 
+// ─── Search result cache (issue #21) ─────────────────────────────────────
+const searchCache = new LRUCache<string, unknown>({ max: 100, ttl: 60_000 })
+
 // ─── Config ───────────────────────────────────────────────────────────────
 const RECEIVING_ADDRESS = config.receivingAddress
 const FACILITATOR_URL   = config.facilitatorUrl
@@ -434,6 +438,13 @@ app.get('/search', async (req: Request, res: Response) => {
     }
     const cleanQ = v.cleanQ
 
+    const cacheKey = `${cleanQ}:${count}:${freshness ?? ''}`
+    const cached = searchCache.get(cacheKey) as SearchResponse | undefined
+    if (cached) {
+      stats.totalQueries++
+      return res.json({ ...cached, cached: true })
+    }
+
     const t0 = Date.now()
 
     const requestBody: Record<string, unknown> = {
@@ -533,6 +544,7 @@ app.get('/search', async (req: Request, res: Response) => {
       txHash,
       latencyMs,
       suggestions,
+      cached: false,
     }
 
     // Record opted-in receipt (cap 50, in-memory)
@@ -544,6 +556,7 @@ app.get('/search', async (req: Request, res: Response) => {
 
     providerDelivered = true
     resultCount = results.length
+    searchCache.set(cacheKey, responseBody)
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[search error]', err.message)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,6 +107,7 @@ export interface SearchResponse {
   txHash: string | null
   latencyMs: number
   suggestions?: string[]
+  cached?: boolean
 }
 
 export interface ImageSearchResponse {


### PR DESCRIPTION
## Summary
- add a bounded 100-entry LRU cache with a 60-second TTL
- key entries by query, result count, and freshness
- count cache hits while returning `cached: true`
- only cache successful Serper responses after payment middleware has accepted the request

Closes #21