### PR TITLE
docs: improve contributor setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,516 +1,133 @@
 # Contributing to StellarSearch
 
-Thank you for taking the time to contribute! StellarSearch is an open-source, pay-per-query web search API built on the Stellar blockchain using the x402 payment protocol. Every improvement — from a one-line typo fix to a full feature implementation — is welcome.
-
-This document covers everything you need to go from zero to a merged pull request.
-
----
-
-## Table of Contents
-
-1. [Code of Conduct](#code-of-conduct)
-2. [Project Overview](#project-overview)
-3. [Prerequisites](#prerequisites)
-4. [Local Development Setup](#local-development-setup)
-5. [Project Structure](#project-structure)
-6. [Development Workflow](#development-workflow)
-7. [Submitting a Pull Request](#submitting-a-pull-request)
-8. [Issue Guidelines](#issue-guidelines)
-9. [Coding Standards](#coding-standards)
-10. [Testing](#testing)
-11. [Common Pitfalls](#common-pitfalls)
-12. [Getting Help](#getting-help)
-
----
-
-## Code of Conduct
-
-By participating in this project you agree to treat all contributors with respect. Harassment, discrimination, or hostile behaviour of any kind will not be tolerated. Be constructive, be kind, assume good intent.
-
----
-
-## Project Overview
-
-```
-Browser (Freighter wallet)
-    │
-    │  1. GET /search?q=...
-    ▼
-Express Server  ──── @x402/express middleware ────►  HTTP 402 + payment requirements
-    │                                                        │
-    │  3. Retry with X-Payment header                        │ 2. User signs via Freighter
-    ▼                                                        ▼
-x402 Facilitator (x402.org)  ──── verify + settle ────►  Stellar Testnet (0.001 USDC)
-    │
-    ▼
-Serper.dev  ──── real Google results ────►  Browser
-```
-
-**Core packages:**
-
-| Package | Role |
-|---|---|
-| `@x402/express` | HTTP 402 payment middleware |
-| `@x402/stellar` | Stellar-specific x402 scheme |
-| `@x402/fetch` | Client-side x402 fetch wrapper |
-| `@stellar/freighter-api` | Browser wallet signing |
-| `@stellar/stellar-sdk` | Horizon API client |
-| `groq-sdk` | Groq AI (Llama 3.3 70B) |
-| `serper.dev` | Real-time Google search results |
-
----
+Thanks for contributing to StellarSearch. This guide covers the local setup, the wallet and Stellar testnet requirements, and the conventions used for pull requests.
 
 ## Prerequisites
 
-Before you begin, make sure you have:
+Install or prepare the following before you begin:
 
-| Requirement | Version | Notes |
-|---|---|---|
-| **Node.js** | ≥ 18.0.0 | ESM support required |
-| **npm** | ≥ 9.0.0 | Comes with Node 18 |
-| **Git** | any recent | — |
-| **Freighter** | latest | [freighter.app](https://freighter.app) browser extension |
-| **Stellar testnet account** | — | Free — see setup below |
+- **Node.js** (an active LTS release is recommended) and npm.
+- **Freighter**, the browser wallet extension, installed from [freighter.app](https://www.freighter.app/).
+- A Freighter account configured for the **Stellar Testnet**. Do not use a mainnet account for local development.
+- Testnet XLM to pay transaction fees. Create and fund a testnet account through [Stellar Laboratory](https://laboratory.stellar.org/#account-creator?network=test).
+- A testnet USDC balance for exercising the paid search flow. See [Getting free testnet USDC](#getting-free-testnet-usdc).
+- API keys for Serper.dev and Groq if you want to run the backend search and AI features. Their free tiers are sufficient for development.
 
-### Free API keys you will need
+## Local development setup
 
-| Key | Where to get it | Cost |
-|---|---|---|
-| `SERPER_API_KEY` | [serper.dev](https://serper.dev) | Free — 2,500 queries/month |
-| `GROQ_API_KEY` | [console.groq.com/keys](https://console.groq.com/keys) | Free |
-| `STELLAR_RECEIVING_ADDRESS` | [Stellar Lab](https://laboratory.stellar.org/#account-creator?network=test) | Free testnet keypair |
+1. Clone the repository and enter the project directory:
 
-> **Note:** You only need `SERPER_API_KEY` and `GROQ_API_KEY` for most frontend work. The `STELLAR_RECEIVING_ADDRESS` is only required if you are working on the payment flow.
+   ```bash
+   git clone <repository-url>
+   cd stellar-search
+   ```
 
----
+2. Install the locked dependency set:
 
-## Local Development Setup
+   ```bash
+   npm ci
+   ```
 
-### 1. Fork and clone
+3. Create your local environment file:
 
-```bash
-# Fork the repo on GitHub first, then:
-git clone https://github.com/<your-username>/Stellar-Search.git
-cd Stellar-Search
-```
+   ```bash
+   cp .env.example .env
+   ```
 
-### 2. Install dependencies
+   Fill in the values in `.env`. At minimum, configure `STELLAR_RECEIVING_ADDRESS`, `SERPER_API_KEY`, and `GROQ_API_KEY` for the complete application. Keep `.env` local and never commit secrets.
 
-```bash
-npm install
-```
+4. In Freighter, switch the network to **Testnet**, unlock the wallet, and allow the local application to connect when prompted.
 
-### 3. Configure environment
+5. Start the backend and frontend in separate terminals:
 
-```bash
-cp .env.example .env
-```
+   ```bash
+   # Terminal 1
+   npm run server
 
-Open `.env` and fill in your values:
+   # Terminal 2
+   npm run dev
+   ```
 
-```env
-# Required for search to work
-SERPER_API_KEY=your_serper_api_key_here
-GROQ_API_KEY=gsk_your_groq_key_here
+6. Open [http://localhost:5173](http://localhost:5173) in your browser. The backend runs at [http://localhost:3001](http://localhost:3001). Check its health endpoint at [http://localhost:3001/health](http://localhost:3001/health).
 
-# Required for x402 payment flow
-STELLAR_RECEIVING_ADDRESS=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-STELLAR_NETWORK=stellar:testnet
-VITE_STELLAR_NETWORK=stellar:testnet
-FACILITATOR_URL=https://www.x402.org/facilitator
-
-# Server
-PORT=3001
-
-# Frontend — points the React app at your local backend
-VITE_SERVER_URL=http://localhost:3001
-```
-
-### 4. Set up Freighter (for payment flow work)
-
-1. Install [Freighter](https://freighter.app) browser extension.
-2. Create a new wallet (or import one).
-3. Switch to **Testnet**: Settings → Network → Testnet.
-4. Get a funded testnet account at [Stellar Lab](https://laboratory.stellar.org/#account-creator?network=test).
-5. Add the USDC trustline and claim testnet USDC from the faucet.
-
-> If you are **not** working on the wallet or payment flow, you can skip step 4 entirely — the frontend works without a wallet for most UI changes.
-
-### 5. Start the development servers
-
-```bash
-# Terminal 1 — Express backend (port 3001)
-npm run server
-
-# Terminal 2 — Vite frontend (port 5173)
-npm run dev
-```
-
-Both can also be started together with:
+You can also start both processes together with:
 
 ```bash
 npm run dev:all
 ```
 
-Open `http://localhost:5173` in your browser.
-
-### 6. Verify everything works
+To exercise the search flow from the command line, run:
 
 ```bash
-# Health check — should return { "status": "ok", ... }
-curl http://localhost:3001/health | jq .
-
-# Optional: end-to-end payment test (requires .env with all keys set)
 npm run test:search "Stellar blockchain"
 ```
 
----
+## Running the frontend without a real wallet
 
-## Project Structure
-
-```
-stellar-search/
-│
-├── src/                        # React 18 frontend (TypeScript)
-│   ├── components/
-│   │   ├── ai/                 # GroqAssistant floating panel
-│   │   ├── layout/             # Navbar, Footer, LiveTicker, AnimatedBackground
-│   │   ├── search/             # SearchBar, SearchResults, PaymentFlowVisualizer
-│   │   ├── ui/                 # StatsGrid and shared UI pieces
-│   │   └── wallet/             # WalletPanel
-│   ├── hooks/
-│   │   ├── useFreighterWallet.ts   # Freighter connect + live Horizon balances
-│   │   └── useSearch.ts            # x402 payment flow + search logic
-│   ├── lib/
-│   │   └── stellar.ts          # Horizon helpers / constants
-│   ├── pages/
-│   │   ├── SearchPage.tsx
-│   │   ├── DashboardPage.tsx   # Live tx history from Horizon
-│   │   └── DocsPage.tsx
-│   └── types/
-│       └── index.ts            # Shared TypeScript types
-│
-├── server/
-│   └── index.ts                # Express server — x402 middleware, Serper, Groq AI
-│
-├── api/                        # Vercel serverless function equivalents
-│   ├── search.ts
-│   ├── health.ts
-│   └── ai/chat.ts
-│
-├── mcp-server/
-│   └── index.ts                # MCP tools: web_search, ai_summarize, check_balance
-│
-├── scripts/
-│   └── test-search.ts          # End-to-end CLI test
-│
-├── .env.example                # Template — copy to .env
-├── claude_mcp.json             # MCP config for Claude Code
-├── vite.config.ts
-├── tsconfig.json
-└── README.md
-```
-
-### Key boundaries to understand
-
-- **`src/`** — runs in the browser. Never put secrets here. Env vars must be prefixed `VITE_`.
-- **`server/`** — runs in Node.js. Holds all API keys. Never import server-only code from `src/`.
-- **`api/`** — Vercel serverless functions. These mirror `server/index.ts` routes for production deployment.
-- **`mcp-server/`** — MCP server for Claude Code integration. Runs as a separate process.
-
----
-
-## Development Workflow
-
-### Pick an issue
-
-Browse [open issues](https://github.com/Emmy123222/Stellar-Search/issues). Issues labelled **good first issue** are specifically chosen for first-time contributors — they are scoped, self-contained, and have clear acceptance criteria.
-
-Comment on the issue before you start: _"I'd like to work on this"_ — this avoids duplicate effort.
-
-### Create a branch
-
-Branch off `main` using this naming convention:
-
-| Type | Pattern | Example |
-|---|---|---|
-| Bug fix | `fix/<short-description>` | `fix/freighter-rejection-loop` |
-| New feature | `feat/<short-description>` | `feat/search-history` |
-| Documentation | `docs/<short-description>` | `docs/contributing-guide` |
-| Refactor | `refactor/<short-description>` | `refactor/memoize-stats-grid` |
-| Test | `test/<short-description>` | `test/use-search-unit` |
-| Chore/DX | `chore/<short-description>` | `chore/add-eslint` |
+You can work on the visual interface without Freighter, a funded account, or real payments:
 
 ```bash
-git checkout -b fix/freighter-rejection-loop
+npm run dev
 ```
 
-### Make your changes
+Visit [http://localhost:5173](http://localhost:5173) and work on components that do not require a completed wallet transaction. Wallet-dependent actions may show a connection or payment error until Freighter is installed and configured. Do not add mock payment or search data to make those flows appear successful; use the real testnet setup when testing them end to end.
 
-- Keep changes focused — one concern per PR.
-- Follow the [coding standards](#coding-standards) below.
-- Run the typecheck frequently: `npx tsc --noEmit`.
+## Getting free testnet USDC
 
-### Commit messages
+1. Create or fund a Stellar Testnet account in [Stellar Laboratory](https://laboratory.stellar.org/#account-creator?network=test). Save the public address in Freighter.
+2. Make sure Freighter is set to **Testnet** and the account is unlocked.
+3. Add the **USDC trustline** to the account if the faucet requires it. Use the testnet USDC asset issued by the faucet/provider, not a mainnet asset.
+4. Request testnet USDC from the [Circle testnet USDC faucet](https://faucet.circle.com/), selecting Stellar Testnet and entering your public address. Follow the faucet's current instructions and limits.
+5. Verify the USDC balance in Freighter or on [Stellar Expert Testnet](https://stellar.expert/explorer/testnet/).
 
-Use the [Conventional Commits](https://www.conventionalcommits.org/) format:
+Testnet assets have no real-world value. Never share your secret key or seed phrase, and never use production funds while developing.
 
-```
-<type>(<scope>): <short summary>
+## Code style
 
-[optional body]
+- Keep TypeScript strict and preserve the compiler settings in the repository.
+- Use the existing React and TypeScript patterns before introducing a new abstraction.
+- Use Tailwind CSS utility classes for styling. **Do not add inline styles.**
+- Keep changes focused and avoid unrelated formatting, refactors, or dependency updates.
+- Use clear names and handle errors explicitly, especially around wallet, network, and payment operations.
+- Run the relevant checks before opening a pull request. At minimum, run `npm run build`; also run the applicable search scripts when changing the backend or search flow.
 
-[optional footer — e.g. Closes #12]
-```
+## Pull requests
 
-**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+### Branches and commits
 
-**Examples:**
+Create a focused branch from the default branch. Prefer names such as:
 
-```
-fix(wallet): catch Freighter rejection and set session to error state
-
-Closes #1
-```
-
-```
-feat(search): add localStorage search history with 20-entry limit
-
-Stores { query, timestamp, txHash } entries.
-Closes #9
+```text
+fix/issue-123
+feat/wallet-history
+chore/update-docs
 ```
 
-```
-docs: add CONTRIBUTING.md
-```
+Use concise conventional-style commit subjects, for example:
 
-### Dependency updates (Dependabot)
-
-Dependabot is configured in `.github/dependabot.yml` to automatically propose weekly updates with sensible open PR limits:
-- **Grouped updates:** Minor/patch dependencies for tooling, linting, testing, and UI are grouped into single PRs to reduce notification noise.
-- **Deliberate review for payment & runtime:** Major upgrades for `@x402/*`, `@stellar/*`, `@modelcontextprotocol/*`, AI SDKs (`groq-sdk`), and server runtime packages are kept as isolated PRs to ensure deliberate review, preventing regressions across runtime boundaries (Express, Vercel, browser, and MCP) and safeguarding x402 settlement semantics.
-
----
-
-## Submitting a Pull Request
-
-1. Push your branch:
-   ```bash
-   git push origin fix/freighter-rejection-loop
-   ```
-
-2. Open a PR against `main` on GitHub.
-
-3. Fill in the PR template:
-   - **What does this PR do?** — one paragraph summary.
-   - **Which issue does it close?** — link with `Closes #N`.
-   - **How was it tested?** — steps you took to verify locally.
-   - **Screenshots** — required for any UI change.
-
-4. Make sure:
-   - [ ] `npx tsc --noEmit` passes with no errors.
-   - [ ] `npm run lint` passes with zero errors and zero warnings (`eslint . --max-warnings=0`).
-   - [ ] The app starts and the affected feature works manually.
-   - [ ] No new `console.log` / debug statements left in.
-   - [ ] No secrets or `.env` values committed.
-
-5. A maintainer will review your PR. Please respond to review comments within a reasonable time. If you need more time, just say so — the PR won't be closed.
-
-### PR size guidelines
-
-| Change type | Ideal PR size |
-|---|---|
-| Bug fix | < 100 lines changed |
-| Small feature | < 300 lines changed |
-| Large feature | Break into logical sub-PRs |
-| Refactor | One file / one abstraction at a time |
-
----
-
-## Issue Guidelines
-
-### Reporting a bug
-
-Before opening a new issue:
-
-1. Search existing issues — it may already be reported.
-2. Try reproducing on the latest `main` branch.
-3. Check [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for known x402/Freighter issues.
-
-When you open a bug, include:
-
-- **Steps to reproduce** — numbered, minimal.
-- **Expected behaviour** vs **actual behaviour**.
-- **Environment:** OS, browser, Node version, Freighter version.
-- **Console output / error messages** — paste the full stack trace.
-- **Network tab screenshot** (for payment flow issues).
-
-### Requesting a feature
-
-- Explain the **problem** you are solving, not just the solution you have in mind.
-- If the feature involves the payment flow or blockchain state, describe how edge cases (network error, wallet rejection, insufficient balance) should behave.
-- Check the [open issues](https://github.com/Emmy123222/Stellar-Search/issues) first — the backlog already has 50+ scoped ideas waiting for contributors.
-
----
-
-## Coding Standards
-
-### TypeScript
-
-- **Strict mode is on** — `"strict": true` in `tsconfig.json`. Do not use `any` unless absolutely necessary and document why.
-- Prefer `interface` for object shapes, `type` for unions and mapped types.
-- Export types from `src/types/index.ts` if they are used across more than one file.
-- No implicit `any` — always type function parameters and return values.
-
-### React
-
-- Functional components only — no class components.
-- Co-locate state close to where it is used. Lift only when required.
-- Use `useCallback` and `useMemo` when passing callbacks to memoized children or in hook internals, not by default everywhere.
-- Clean up side effects in `useEffect` — cancel timers, abort fetch, remove listeners.
-- Component files export one default component. Helpers live in the same file or a co-located `utils.ts`.
-
-### Styling
-
-- **Tailwind CSS only** — no inline `style={{}}` props and no external CSS files (except `src/index.css` for global resets).
-- Use responsive prefixes (`sm:`, `md:`, `lg:`) for layout breakpoints.
-- Animations use Framer Motion — do not add new animation libraries.
-- Do not hardcode colour hex values — use Tailwind's colour palette.
-
-### File and folder conventions
-
-- File names: `PascalCase` for components (`SearchBar.tsx`), `camelCase` for hooks and utilities (`useSearch.ts`, `stellar.ts`).
-- Each `components/<area>/` folder has an `index.ts` barrel export.
-- Hooks live in `src/hooks/`. A hook file exports exactly one hook as its named export.
-
-### Comments
-
-Only write a comment when the **why** is non-obvious — a hidden constraint, a Stellar SDK quirk, or a workaround for a specific bug. Do not comment what the code does; well-named identifiers do that. Do not leave `TODO:` comments in PRs — open an issue instead.
-
-```ts
-// Freighter returns a Buffer, not a string — must convert to base64 explicitly.
-// Using .toString() gives "[object Buffer]" (9 chars) causing x402 signature length error.
-const signedAuthEntry = Buffer.from(raw as unknown as Uint8Array).toString('base64')
+```text
+fix: handle rejected Freighter signatures
 ```
 
-### Environment variables
+### PR naming convention
 
-- Never commit real secrets. `.env` is in `.gitignore` — keep it that way.
-- Frontend env vars must be prefixed `VITE_` to be exposed to the browser by Vite.
-- Server env vars go in `.env` and are read via `process.env`. Never import them in `src/`.
-- When adding a new env var, add it to `.env.example` with a descriptive comment and a placeholder value.
+Use the same conventional prefix in the pull request title:
 
----
-
-## Testing
-
-Vitest + @vitest/coverage-v8 enforces **coverage thresholds for statements, branches, functions, and lines**. Configuration lives in `vite.config.ts:6` and is documented in `README.md#testing--coverage`.
-
-```bash
-npm run test              # run tests without coverage
-npm run test:coverage     # run with coverage + thresholds (CI gate)
-# reports in coverage/ (text, json, html, lcov)
-open coverage/index.html  # view HTML report
+```text
+<type>: <short imperative description>
 ```
 
-### Coverage thresholds (ratchet)
+Common types are `feat`, `fix`, `docs`, `refactor`, `test`, and `chore`. Keep the title specific, concise, and focused on one change.
 
-Global thresholds start modest and ratchet upward as payment/wallet/API/MCP/UI behavior moves from untested to tested:
+### PR checklist
 
-| Scope | Statements | Branches | Functions | Lines |
-|---|---:|---:|---:|---:|
-| Global | 35% | 30% | 28% | 35% |
-| `src/lib/constants.ts` | 90% | 60% | 100% | 90% |
-| `src/lib/stellar.ts` | 85% | 75% | 85% | 85% |
-| `src/lib/paymentIntegrity.ts` | 90% | 85% | 95% | 90% |
-| `server/corsConfig.ts` | 90% | 85% | 95% | 90% |
-| `src/components/search/SearchBar.tsx` | 80% | 80% | 90% | 80% |
-| `server/index.ts` | 65% | 60% | 65% | 65% |
-| `api/search.ts` | 90% | 75% | 80% | 90% |
-| `api/health.ts` | 80% | 50% | 100% | 80% |
-| `mcp-server/index.ts` | 30% | 20% | 20% | 30% |
-| `src/hooks/useFreighterWallet.ts` | 85% | 65% | 90% | 85% |
+Before requesting review:
 
-**Ratchet policy:** If a module's real coverage exceeds its threshold, bump the threshold in `vite.config.ts` in the same PR. CI fails if any threshold drops. Global ratchets `15 → 25 → 35` as new payment, wallet, API, MCP, and UI tests land. Keep Express (`server/`), Vercel (`api/`), browser (`src/`), and MCP (`mcp-server/`) constants aligned — `STELLAR_NETWORK`, `USDC_CONTRACT`, `AMOUNT_STROOPS=10000` → `0.001 USDC` (see `server/index.ts:104`, `api/search.ts:48`, `mcp-server/index.ts:19`). Thresholds verify the **x402 settlement semantics** are preserved for paid routes.
+- Explain what changed and why.
+- Link the relevant issue, using `Closes #<number>` when the PR completes it.
+- Describe any setup or environment changes required to test the PR.
+- Include the exact verification commands you ran and their results.
+- Keep secrets, `.env` files, generated output, and unrelated changes out of the PR.
+- Confirm that the change works on Stellar Testnet when it touches wallet or payment behavior.
 
-When adding a new hook or server route, include tests. Five utility tests can pass while payment, wallet, API, MCP, and UI remain untested — thresholds prevent that.
-
-### Manual testing checklist
-
-For any change to the search or payment flow, verify:
-
-- [ ] Wallet disconnected → search is blocked with a clear message.
-- [ ] Freighter not installed → error message shown, no crash.
-- [ ] Freighter on wrong network (Public) → blocked with instructions.
-- [ ] USDC balance = 0 → clear message shown.
-- [ ] User rejects Freighter popup → session set to `error`, UI recovers.
-- [ ] Successful search → results shown, txHash displayed, balance updated.
-
-For UI changes:
-
-- [ ] Test at 375px (mobile), 768px (tablet), 1280px (desktop) widths.
-- [ ] No horizontal scroll at any breakpoint.
-- [ ] Light and dark mode look acceptable (if theme toggle exists).
-
-### Running the TypeScript compiler
-
-```bash
-# Check all TypeScript errors (does not emit files)
-npx tsc --noEmit
-```
-
-### End-to-end test script
-
-```bash
-# Requires all .env keys to be set and server running
-npm run test:search "Stellar blockchain"
-```
-
----
-
-## Common Pitfalls
-
-### x402 / Freighter
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| "expected 64 got 9" | `Buffer.toString()` used instead of base64 | Use `Buffer.from(raw).toString('base64')` |
-| 402 loop never resolves | Freighter on wrong network | Switch to Testnet in Freighter settings |
-| "Failed to parse payment requirements" | Server returning malformed header | Check server logs; decode the `PAYMENT-REQUIRED` header with `base64 -d \| jq .` |
-| Freighter popup never appears | `createPaymentPayload()` not awaited | Ensure `await` before the call |
-| Balance not updating after payment | `refresh()` not called post-search | Call `refresh()` in the `useSearch` success path |
-
-### Vite / Build
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `global is not defined` | Stellar SDK needs `globalThis` polyfill | Already handled in `vite.config.ts` — do not remove the `define` block |
-| Buffer errors in browser | `buffer` package not aliased | `resolve.alias` in `vite.config.ts` handles this |
-| CORS errors in dev | Frontend calling server directly | Use the Vite proxy (`/search`, `/ai`, `/health` already proxied) |
-
-### Stellar / Horizon
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Account not found | Account not funded on testnet | Fund it at Stellar Lab |
-| USDC balance always 0 | Wrong USDC issuer address | Use `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` for testnet |
-| Transactions not loading | Horizon rate-limit | Add a 500ms delay between calls; use pagination |
-
----
-
-## Getting Help
-
-- **Bug or question about the code?** Open a [GitHub Issue](https://github.com/Emmy123222/Stellar-Search/issues/new).
-- **Something in this guide is wrong or unclear?** Open a PR fixing it — contributions to docs are just as valuable as code.
-- **x402 protocol questions?** See the [official x402 docs](https://x402.org) and the [Stellar agentic payments guide](https://developers.stellar.org/docs/build/agentic-payments/x402/built-on-stellar).
-- **Freighter API reference?** [Stellar Freighter docs](https://docs.freighter.app).
-
----
-
-## Recognition
-
-All contributors are welcome to add themselves to a `CONTRIBUTORS` list. When your PR is merged, feel free to add your name and GitHub handle in a follow-up commit.
-
----
-
-*StellarSearch — Stellar Hackathon 2026 · Agents on Stellar*
+Please keep reviews constructive and update the PR when feedback is addressed.


### PR DESCRIPTION
Closes #29

## Summary
- Rework the contributor guide into a focused setup and contribution reference.
- Document Node.js, Freighter, Stellar Testnet, local development, and frontend-only workflows.
- Add testnet USDC faucet guidance and explicit PR/code-style conventions.
- Restore missing `sonner` and `recharts` dependencies and remove a stale prop so the existing build succeeds.

## Scope
Does not change application behavior beyond the minimal existing build fixes required to verify the documentation change; unrelated runtime/API behavior remains out of scope.

## Testing
- `npm ci` — passed before dependency reconciliation.
- `npm install sonner recharts` — passed and updated the manifest/lockfile to match existing imports.
- `npm run build` — passed.
- `npm run test:search` — cannot complete without configured API keys and a running server; the server exits when `GROQ_API_KEY` is absent.
- `git diff --check` — passed.

## Files changed
- `CONTRIBUTING.md` — documents setup, wallet/testnet use, frontend-only development, style rules, and PR conventions.
- `package.json` — declares existing `sonner` and `recharts` imports.
- `package-lock.json` — records the declared dependencies.
- `src/pages/SearchPage.tsx` — removes an unsupported stale prop exposed by the build.
