### PR TITLE
fix(payment): ensure x402 payment integrity and replay protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 
 # Local scripts
 create_issues.py
+coverage/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,12 +412,13 @@ Global thresholds start modest and ratchet upward as payment/wallet/API/MCP/UI b
 
 | Scope | Statements | Branches | Functions | Lines |
 |---|---:|---:|---:|---:|
-| Global | 25% | 23% | 20% | 26% |
+| Global | 35% | 30% | 28% | 35% |
 | `src/lib/constants.ts` | 90% | 60% | 100% | 90% |
 | `src/lib/stellar.ts` | 85% | 75% | 85% | 85% |
+| `src/lib/paymentIntegrity.ts` | 90% | 85% | 95% | 90% |
 | `server/corsConfig.ts` | 90% | 85% | 95% | 90% |
 | `src/components/search/SearchBar.tsx` | 80% | 80% | 90% | 80% |
-| `server/index.ts` | 35% | 30% | 35% | 35% |
+| `server/index.ts` | 65% | 60% | 65% | 65% |
 | `api/search.ts` | 90% | 75% | 80% | 90% |
 | `api/health.ts` | 80% | 50% | 100% | 80% |
 | `mcp-server/index.ts` | 30% | 20% | 20% | 30% |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ Browser (Freighter) → GET /search?q=...
 3. The x402 client signs a Soroban authorization entry via Freighter wallet
 4. Retries with `X-Payment` header containing the signed entry
 5. OpenZeppelin facilitator at `channels.openzeppelin.com/x402/testnet` verifies the signature and settles 0.001 USDC on Stellar testnet
-6. Server receives confirmation and returns search results
+6. Server enforces payment integrity (`src/lib/paymentIntegrity.ts`), rejecting replayed or duplicate payloads within the 300-second validity window, and returns search results
+
+### Payment Integrity & Replay Protection
+
+To guarantee that each payment identifier authorizes **exactly one provider call**, StellarSearch tracks consumed payment identifiers across Express (`server/index.ts`) and Vercel (`api/search.ts`) runtimes:
+- **Payload Invalidation:** Extracts transaction hashes (or SHA-256 fallback hashes of payment headers) and invalidates consumed payloads for a 300-second window.
+- **Concurrency Throttling:** Rapid parallel requests using identical payment payloads are throttled so only one search query proceeds; concurrent duplicates immediately receive HTTP 402 (`Payment payload already consumed`).
 
 ### Sequence diagram
 
@@ -214,12 +220,13 @@ Global thresholds are deliberately modest initially and ratchet upward as paymen
 
 | Scope | Statements | Branches | Functions | Lines |
 |---|---:|---:|---:|---:|
-| **Global** | 25% | 23% | 20% | 26% |
+| **Global** | 35% | 30% | 28% | 35% |
 | `src/lib/constants.ts` | 90% | 60% | 100% | 90% |
 | `src/lib/stellar.ts` | 85% | 75% | 85% | 85% |
+| `src/lib/paymentIntegrity.ts` | 90% | 85% | 95% | 90% |
 | `server/corsConfig.ts` | 90% | 85% | 95% | 90% |
 | `src/components/search/SearchBar.tsx` | 80% | 80% | 90% | 80% |
-| `server/index.ts` | 35% | 30% | 35% | 35% |
+| `server/index.ts` | 65% | 60% | 65% | 65% |
 | `api/search.ts` | 90% | 75% | 80% | 90% |
 | `api/health.ts` | 80% | 50% | 100% | 80% |
 | `mcp-server/index.ts` | 30% | 20% | 20% | 30% |

--- a/api/search.test.ts
+++ b/api/search.test.ts
@@ -17,6 +17,7 @@ vi.mock('../src/lib/constants', async () => {
 })
 
 import handler from './search'
+import { resetConsumedPayments } from '../src/lib/paymentIntegrity'
 
 function mockReqRes(overrides: any = {}) {
   const req: any = {
@@ -45,6 +46,7 @@ describe('api/search — Vercel x402 settlement (aligned with Express)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetConsumedPayments()
     global.fetch = originalFetch
   })
 
@@ -172,5 +174,63 @@ describe('api/search — Vercel x402 settlement (aligned with Express)', () => {
     })
     await handler(req, res)
     expect(capturedBody.tbs).toBe('qdr:w')
+  })
+
+  it('rejects replayed payment headers for their validity window', async () => {
+    const fakeTx = Buffer.from(JSON.stringify({ transactionHash: 'tx_replay_test_123' })).toString('base64')
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ organic: [] }),
+    } as any)
+
+    // Request 1: first time — should succeed
+    const first = mockReqRes({
+      method: 'GET',
+      query: { q: 'stellar' },
+      headers: { 'x-payment': fakeTx },
+    })
+    await handler(first.req, first.res)
+    expect(first.res._json.query).toBe('stellar')
+
+    // Request 2: second time — must be rejected as already consumed
+    const second = mockReqRes({
+      method: 'GET',
+      query: { q: 'stellar' },
+      headers: { 'x-payment': fakeTx },
+    })
+    await handler(second.req, second.res)
+    expect(second.res._status).toBe(402)
+    expect(second.res._json.error).toBe('Payment payload already consumed')
+  })
+
+  it('concurrency test: proves only one search proceeds for the exact same payload', async () => {
+    const fakeTx = Buffer.from(JSON.stringify({ transactionHash: 'tx_concurrency_test_456' })).toString('base64')
+    global.fetch = vi.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      return {
+        ok: true,
+        json: async () => ({ organic: [{ title: 'Stellar Concurrent', link: 'https://stellar.org' }] }),
+      } as any
+    })
+
+    const numConcurrent = 5
+    const pairs = Array.from({ length: numConcurrent }, () =>
+      mockReqRes({
+        method: 'GET',
+        query: { q: 'stellar' },
+        headers: { 'x-payment': fakeTx },
+      })
+    )
+
+    await Promise.all(pairs.map((p) => handler(p.req, p.res)))
+
+    // Upstream Serper fetch must be called EXACTLY ONCE
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    const successes = pairs.filter((p) => p.res._json?.results)
+    const rejections = pairs.filter((p) => p.res._status === 402 && p.res._json?.error === 'Payment payload already consumed')
+
+    expect(successes).toHaveLength(1)
+    expect(rejections).toHaveLength(numConcurrent - 1)
   })
 })

--- a/api/search.ts
+++ b/api/search.ts
@@ -5,6 +5,7 @@ import {
   AMOUNT_STROOPS,
   AMOUNT_USDC
 } from '../src/lib/constants'
+import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
 
 // ─── Config ───────────────────────────────────────────────────────────────
 const RECEIVING_ADDRESS = process.env.STELLAR_RECEIVING_ADDRESS!
@@ -71,6 +72,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       Buffer.from(JSON.stringify(paymentRequired)).toString('base64')
     )
     return res.status(402).json({ error: 'Payment required' })
+  }
+
+  // ─── Payment Replay Protection ───────────────────────────────────────────
+  const consumption = consumePaymentPayload(paymentHeader)
+  if (!consumption.ok) {
+    return res.status(402).json({ error: consumption.error })
   }
 
   // ─── Payment present — proceed with search ────────────────────────────────

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import {
   AMOUNT_USDC,
   AMOUNT_STROOPS
 } from '../src/lib/constants'
+import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
 
 dotenv.config()
 
@@ -153,6 +154,27 @@ app.use((req, res, next) => {
 });
 
 app.use(paymentMiddlewareFromConfig(x402Routes, facilitatorClient, schemes))
+
+// ─── Payment Replay Protection Middleware ─────────────────────────────────
+app.use((req, res, next) => {
+  const paidRoutes = ['/search', '/images', '/news']
+  if (paidRoutes.includes(req.path)) {
+    const paymentHeader =
+      req.headers['payment-signature'] ||
+      req.headers['x-payment'] ||
+      req.headers['X-PAYMENT'] ||
+      req.headers['x-payment-response'] ||
+      req.headers['authorization']
+
+    if (paymentHeader) {
+      const consumption = consumePaymentPayload(paymentHeader)
+      if (!consumption.ok) {
+        return res.status(402).json({ error: consumption.error })
+      }
+    }
+  }
+  next()
+})
 
 export const MAX_QUERY_LENGTH = 256
 
@@ -574,7 +596,7 @@ app.get('/', (_req: Request, res: Response) => {
 })
 
 // ─── Start ────────────────────────────────────────────────────────────────
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   app.listen(PORT, () => {
     console.log(`\n🚀 StellarSearch on http://localhost:${PORT}`)
     console.log(`   Network:     ${NETWORK}`)

--- a/server/payment.test.ts
+++ b/server/payment.test.ts
@@ -1,0 +1,394 @@
+/**
+ * server/payment.test.ts
+ *
+ * Offline protocol tests for x402 payment flows on Express routes.
+ * All scenarios run without a private key, real transfer, or network call.
+ *
+ * Scenarios covered:
+ *   - challenge   : validation gate returns 400 for bad queries
+ *   - settle      : valid payment passes and returns search results
+ *   - reject      : Serper upstream errors propagate with correct status codes
+ *   - expire      : payment consumed outside validity window is accepted again
+ *   - replay      : same tx hash rejected within validity window
+ *   - malformed   : garbled / truncated / wrong-type receipt headers
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import request from 'supertest'
+
+// ─── Mock x402 + heavy deps before app import ───────────────────────────────
+vi.mock('@x402/express', () => ({
+  paymentMiddlewareFromConfig: () => (_req: any, _res: any, next: any) => next(),
+}))
+vi.mock('@x402/core/server', () => ({
+  HTTPFacilitatorClient: class { constructor(_opts: any) {} },
+}))
+vi.mock('@x402/stellar/exact/server', () => ({
+  ExactStellarScheme: class { constructor() {} },
+}))
+vi.mock('groq-sdk', () => ({
+  default: class {
+    chat = { completions: { create: vi.fn() } }
+  },
+}))
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+process.env.STELLAR_RECEIVING_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+process.env.SERPER_API_KEY = 'test-serper-key'
+process.env.GROQ_API_KEY = 'gsk_test'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeReceipt(txHash: string): string {
+  return Buffer.from(JSON.stringify({ transactionHash: txHash })).toString('base64')
+}
+
+const SERPER_STUB = {
+  organic: [
+    { title: 'Stellar', link: 'https://stellar.org', snippet: 'Blockchain for the internet', date: '2026-01-01' },
+  ],
+}
+
+function mockFetchOk() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => SERPER_STUB,
+  } as any)
+}
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+let app: any
+
+beforeEach(async () => {
+  vi.resetModules()
+
+  const { resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+  resetConsumedPayments()
+
+  const mod = await import('./index.js')
+  app = mod.default
+
+  global.fetch = mockFetchOk()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ─── Challenge ───────────────────────────────────────────────────────────────
+
+describe('challenge — query validation gate (pre-payment)', () => {
+  it('returns 400 when q is missing', async () => {
+    const res = await request(app).get('/search')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Missing required parameter/)
+  })
+
+  it('returns 400 when q is whitespace', async () => {
+    const res = await request(app).get('/search?q=%20%20')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Missing required parameter/)
+  })
+
+  it('returns 400 when q exceeds 256 characters', async () => {
+    const res = await request(app).get(`/search?q=${'a'.repeat(257)}`)
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Query too long/)
+  })
+
+  it('returns 400 for q that is only control characters', async () => {
+    const res = await request(app).get('/search?q=%00%01%1F')
+    expect(res.status).toBe(400)
+  })
+
+  it('challenge also fires on /images missing q', async () => {
+    const res = await request(app).get('/images')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Missing required parameter/)
+  })
+
+  it('challenge also fires on /news missing q', async () => {
+    const res = await request(app).get('/news')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Missing required parameter/)
+  })
+})
+
+// ─── Settle ──────────────────────────────────────────────────────────────────
+
+describe('settle — successful search after payment', () => {
+  it('returns 200 with search results from Serper', async () => {
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_settle_1'))
+    expect(res.status).toBe(200)
+    expect(res.body.results).toHaveLength(1)
+    expect(res.body.results[0].title).toBe('Stellar')
+  })
+
+  it('response includes x402 settlement metadata', async () => {
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_settle_meta'))
+    expect(res.status).toBe(200)
+    expect(res.body.paidAmount).toBe('0.001')
+    expect(res.body.currency).toBe('USDC')
+    expect(res.body.network).toMatch(/^stellar:/)
+    expect(typeof res.body.latencyMs).toBe('number')
+    expect(res.body.latencyMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('respects count param and returns correct result count', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        organic: Array.from({ length: 3 }, (_, i) => ({
+          title: `Result ${i}`,
+          link: `https://example.com/${i}`,
+          snippet: 'desc',
+        })),
+      }),
+    } as any)
+    const res = await request(app).get('/search?q=stellar&count=3').set('x-payment', makeReceipt('tx_settle_count'))
+    expect(res.status).toBe(200)
+    expect(res.body.count).toBe(3)
+  })
+
+  it('settle on /images returns image results with x402 metadata', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        images: [{ title: 'Img', imageUrl: 'https://i.example.com/1.jpg', link: 'https://example.com' }],
+      }),
+    } as any)
+    const res = await request(app).get('/images?q=stellar+logo').set('x-payment', makeReceipt('tx_settle_img'))
+    expect(res.status).toBe(200)
+    expect(res.body.results[0].imageUrl).toBe('https://i.example.com/1.jpg')
+    expect(res.body.currency).toBe('USDC')
+    expect(res.body.paidAmount).toBe('0.001')
+  })
+
+  it('settle on /news returns news results with x402 metadata', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        news: [{ title: 'News', link: 'https://news.example.com/1', snippet: 'Article', source: 'Example', date: '2026-01-01' }],
+      }),
+    } as any)
+    const res = await request(app).get('/news?q=stellar').set('x-payment', makeReceipt('tx_settle_news'))
+    expect(res.status).toBe(200)
+    expect(res.body.results[0].title).toBe('News')
+    expect(res.body.network).toMatch(/^stellar:/)
+  })
+
+  it('applies freshness filter pw → qdr:w when param is set', async () => {
+    let capturedBody: any = null
+    global.fetch = vi.fn().mockImplementation(async (_url: string, opts: any) => {
+      capturedBody = JSON.parse(opts.body)
+      return { ok: true, json: async () => ({ organic: [] }) } as any
+    })
+    const res = await request(app).get('/search?q=stellar&freshness=pw').set('x-payment', makeReceipt('tx_freshness'))
+    expect(res.status).toBe(200)
+    expect(capturedBody.tbs).toBe('qdr:w')
+  })
+})
+
+// ─── Reject ───────────────────────────────────────────────────────────────────
+
+describe('reject — upstream errors after payment header is present', () => {
+  it('returns 502 when Serper responds 500', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => 'internal error' } as any)
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_500'))
+    expect(res.status).toBe(502)
+    expect(res.body.error).toMatch(/Serper/)
+  })
+
+  it('returns 502 when Serper responds 403 (bad API key)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403, text: async () => 'forbidden' } as any)
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_403'))
+    expect(res.status).toBe(502)
+  })
+
+  it('returns 502 when /images Serper responds with error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429, text: async () => 'rate limited' } as any)
+    const res = await request(app).get('/images?q=stellar').set('x-payment', makeReceipt('tx_rej_img'))
+    expect(res.status).toBe(502)
+  })
+
+  it('returns 500 when fetch throws (network failure)', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_net'))
+    expect(res.status).toBe(500)
+  })
+})
+
+// ─── Replay ──────────────────────────────────────────────────────────────────
+
+describe('replay — same payment cannot be re-used within validity window', () => {
+  it('rejects same tx hash on second consumePaymentPayload call', async () => {
+    const { consumePaymentPayload, resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const receipt = makeReceipt('tx_replay_1')
+    expect(consumePaymentPayload(receipt).ok).toBe(true)
+    const second = consumePaymentPayload(receipt)
+    expect(second.ok).toBe(false)
+    if (!second.ok) expect(second.error).toBe('Payment payload already consumed')
+  })
+
+  it('rejects 20 concurrent replay attempts — exactly one succeeds', async () => {
+    const { consumePaymentPayload, resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const receipt = makeReceipt('tx_replay_concurrent')
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => Promise.resolve().then(() => consumePaymentPayload(receipt)))
+    )
+    expect(results.filter((r) => r.ok)).toHaveLength(1)
+    expect(results.filter((r) => !r.ok)).toHaveLength(19)
+  })
+
+  it('rejects object-form receipt when base64 form already consumed', async () => {
+    const { consumePaymentPayload, resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const base64 = makeReceipt('tx_replay_dual')
+    const obj = { transactionHash: 'tx_replay_dual' }
+    expect(consumePaymentPayload(base64).ok).toBe(true)
+    expect(consumePaymentPayload(obj).ok).toBe(false)
+  })
+
+  it('isPaymentConsumed returns true after consumption', async () => {
+    const { consumePaymentPayload, isPaymentConsumed, resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const receipt = makeReceipt('tx_replay_check')
+    expect(isPaymentConsumed(receipt)).toBe(false)
+    consumePaymentPayload(receipt)
+    expect(isPaymentConsumed(receipt)).toBe(true)
+  })
+})
+
+// ─── Expire ───────────────────────────────────────────────────────────────────
+
+describe('expire — consumed payment accepted again after validity window', () => {
+  it('re-allows a payment receipt after 300s validity window', async () => {
+    const { consumePaymentPayload, resetConsumedPayments, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS } =
+      await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const receipt = makeReceipt('tx_expire_1')
+    const t0 = 1_000_000
+    expect(consumePaymentPayload(receipt, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS, t0).ok).toBe(true)
+    expect(consumePaymentPayload(receipt, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS, t0 + 299_000).ok).toBe(false)
+    expect(consumePaymentPayload(receipt, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS, t0 + 301_000).ok).toBe(true)
+  })
+
+  it('DEFAULT_PAYMENT_VALIDITY_WINDOW_MS is 300_000ms (aligned with x402 maxTimeoutSeconds)', async () => {
+    const { DEFAULT_PAYMENT_VALIDITY_WINDOW_MS } = await import('../src/lib/paymentIntegrity')
+    expect(DEFAULT_PAYMENT_VALIDITY_WINDOW_MS).toBe(300_000)
+  })
+
+  it('cleanupExpiredPayments purges only expired entries', async () => {
+    const { consumePaymentPayload, cleanupExpiredPayments, getConsumedPaymentsCount, resetConsumedPayments } =
+      await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const t0 = 1_000_000
+    consumePaymentPayload(makeReceipt('tx_short'), 1_000, t0)
+    consumePaymentPayload(makeReceipt('tx_long'), 5_000, t0)
+    expect(getConsumedPaymentsCount()).toBe(2)
+    cleanupExpiredPayments(t0 + 2_000)
+    expect(getConsumedPaymentsCount()).toBe(1)
+    cleanupExpiredPayments(t0 + 6_000)
+    expect(getConsumedPaymentsCount()).toBe(0)
+  })
+})
+
+// ─── Malformed receipts ───────────────────────────────────────────────────────
+
+describe('malformed — garbled, truncated, or wrong-type receipt headers', () => {
+  it('null returns no paymentId', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier(null)).toBeNull()
+  })
+
+  it('undefined returns no paymentId', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier(undefined)).toBeNull()
+  })
+
+  it('empty string returns no paymentId', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier('')).toBeNull()
+    expect(extractPaymentIdentifier('   ')).toBeNull()
+  })
+
+  it('number type returns no paymentId', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier(42 as any)).toBeNull()
+  })
+
+  it('boolean type returns no paymentId', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier(true as any)).toBeNull()
+  })
+
+  it('truncated base64 falls back to SHA-256 hash identifier', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    const truncated = makeReceipt('tx_trunc').slice(0, 10)
+    expect(extractPaymentIdentifier(truncated)).toMatch(/^hash:[a-f0-9]{64}$/)
+  })
+
+  it('plain non-base64 string falls back to SHA-256 hash identifier', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier('not-a-real-receipt')).toMatch(/^hash:[a-f0-9]{64}$/)
+  })
+
+  it('base64 JSON missing known id fields falls back to SHA-256', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    const noId = Buffer.from(JSON.stringify({ randomField: 'value' })).toString('base64')
+    expect(extractPaymentIdentifier(noId)).toMatch(/^hash:[a-f0-9]{64}$/)
+  })
+
+  it('two different malformed headers produce different identifiers', async () => {
+    const { extractPaymentIdentifier } = await import('../src/lib/paymentIntegrity')
+    expect(extractPaymentIdentifier('garbage-1')).not.toBe(extractPaymentIdentifier('garbage-2'))
+  })
+
+  it('consumePaymentPayload returns error for null header', async () => {
+    const { consumePaymentPayload, resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const result = consumePaymentPayload(null)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/Invalid or missing/)
+  })
+
+  it('consumePaymentPayload accepts truncated base64 via hash fallback', async () => {
+    const { consumePaymentPayload, resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+    resetConsumedPayments()
+    const truncated = makeReceipt('tx_trunc_consume').slice(0, 12)
+    const result = consumePaymentPayload(truncated)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.paymentId).toMatch(/^hash:[a-f0-9]{64}$/)
+  })
+})
+
+// ─── x402 settlement semantics ────────────────────────────────────────────────
+
+describe('x402 settlement semantics — Express + Vercel constants aligned', () => {
+  it('AMOUNT_STROOPS is 10000 (0.001 USDC)', async () => {
+    const { AMOUNT_STROOPS, AMOUNT_USDC } = await import('../src/lib/constants')
+    expect(parseInt(AMOUNT_STROOPS)).toBe(10_000)
+    expect(AMOUNT_USDC).toBe('0.001')
+  })
+
+  it('STELLAR_NETWORK is a valid x402 network identifier', async () => {
+    const { STELLAR_NETWORK } = await import('../src/lib/constants')
+    expect(STELLAR_NETWORK).toMatch(/^stellar:(testnet|mainnet)$/)
+  })
+
+  it('USDC_CONTRACT is a valid Soroban contract address (starts with C, 56 chars)', async () => {
+    const { USDC_CONTRACT } = await import('../src/lib/constants')
+    expect(USDC_CONTRACT).toMatch(/^C[A-Z2-7]{55}$/)
+  })
+
+  it('settled /search response latencyMs is a non-negative number', async () => {
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_latency'))
+    expect(res.status).toBe(200)
+    expect(res.body.latencyMs).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/src/lib/paymentIntegrity.test.ts
+++ b/src/lib/paymentIntegrity.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  extractPaymentIdentifier,
+  consumePaymentPayload,
+  isPaymentConsumed,
+  cleanupExpiredPayments,
+  resetConsumedPayments,
+  getConsumedPaymentsCount,
+  DEFAULT_PAYMENT_VALIDITY_WINDOW_MS,
+} from './paymentIntegrity'
+
+describe('src/lib/paymentIntegrity — Replay Protection & Payload Tracking', () => {
+  beforeEach(() => {
+    resetConsumedPayments()
+  })
+
+  describe('extractPaymentIdentifier', () => {
+    it('returns null for null, undefined, or empty values', () => {
+      expect(extractPaymentIdentifier(null)).toBeNull()
+      expect(extractPaymentIdentifier(undefined)).toBeNull()
+      expect(extractPaymentIdentifier('')).toBeNull()
+      expect(extractPaymentIdentifier('   ')).toBeNull()
+    })
+
+    it('extracts explicit transactionHash from JSON object', () => {
+      const id = extractPaymentIdentifier({ transactionHash: 'tx_12345' })
+      expect(id).toBe('tx:tx_12345')
+    })
+
+    it('extracts explicit txHash from base64 JSON header string', () => {
+      const payload = Buffer.from(JSON.stringify({ txHash: 'hash_abc' })).toString('base64')
+      const id = extractPaymentIdentifier(payload)
+      expect(id).toBe('tx:hash_abc')
+    })
+
+    it('extracts signature/id/nonce from parsed JSON', () => {
+      expect(extractPaymentIdentifier({ signature: 'sig_999' })).toBe('tx:sig_999')
+      expect(extractPaymentIdentifier({ id: 'id_777' })).toBe('tx:id_777')
+      expect(extractPaymentIdentifier({ nonce: 'nonce_555' })).toBe('tx:nonce_555')
+    })
+
+    it('falls back to SHA-256 hash for raw non-JSON header strings', () => {
+      const rawHeader = 'X-Payment-Signature-Raw-Token-Value'
+      const id = extractPaymentIdentifier(rawHeader)
+      expect(id).toMatch(/^hash:[a-f0-9]{64}$/)
+    })
+
+    it('produces identical identifier for same raw header string', () => {
+      const rawHeader = 'X-Payment-Signature-Raw-Token-Value'
+      expect(extractPaymentIdentifier(rawHeader)).toBe(extractPaymentIdentifier(rawHeader))
+    })
+  })
+
+  describe('consumePaymentPayload & isPaymentConsumed', () => {
+    it('successfully consumes a fresh payment payload on first attempt', () => {
+      const header = Buffer.from(JSON.stringify({ transactionHash: 'tx_first' })).toString('base64')
+      const result = consumePaymentPayload(header)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.paymentId).toBe('tx:tx_first')
+      }
+      expect(isPaymentConsumed(header)).toBe(true)
+    })
+
+    it('rejects a consumed payment payload on second attempt within validity window', () => {
+      const header = Buffer.from(JSON.stringify({ transactionHash: 'tx_replay' })).toString('base64')
+      const first = consumePaymentPayload(header)
+      expect(first.ok).toBe(true)
+
+      const second = consumePaymentPayload(header)
+      expect(second.ok).toBe(false)
+      if (!second.ok) {
+        expect(second.error).toBe('Payment payload already consumed')
+        expect(second.paymentId).toBe('tx:tx_replay')
+      }
+    })
+
+    it('rejects alternative base64 format representing the same transactionHash', () => {
+      const jsonStr = JSON.stringify({ transactionHash: 'tx_shared' })
+      const headerBase64 = Buffer.from(jsonStr).toString('base64')
+      const headerObject = { transactionHash: 'tx_shared' }
+
+      expect(consumePaymentPayload(headerBase64).ok).toBe(true)
+      expect(consumePaymentPayload(headerObject).ok).toBe(false)
+    })
+
+    it('allows re-consumption after the validity window expires', () => {
+      const header = Buffer.from(JSON.stringify({ transactionHash: 'tx_expired' })).toString('base64')
+      const t0 = 1000000
+
+      // Consume at t0
+      const res1 = consumePaymentPayload(header, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS, t0)
+      expect(res1.ok).toBe(true)
+
+      // Reject at t0 + 299 seconds
+      const res2 = consumePaymentPayload(header, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS, t0 + 299 * 1000)
+      expect(res2.ok).toBe(false)
+
+      // Allow at t0 + 301 seconds (expired)
+      const res3 = consumePaymentPayload(header, DEFAULT_PAYMENT_VALIDITY_WINDOW_MS, t0 + 301 * 1000)
+      expect(res3.ok).toBe(true)
+    })
+
+    it('purges expired entries via cleanupExpiredPayments', () => {
+      const h1 = { transactionHash: 'tx_1' }
+      const h2 = { transactionHash: 'tx_2' }
+      const t0 = 1000000
+
+      consumePaymentPayload(h1, 1000, t0) // expires at t0 + 1000
+      consumePaymentPayload(h2, 5000, t0) // expires at t0 + 5000
+
+      expect(getConsumedPaymentsCount()).toBe(2)
+
+      cleanupExpiredPayments(t0 + 2000)
+      expect(getConsumedPaymentsCount()).toBe(1)
+
+      cleanupExpiredPayments(t0 + 6000)
+      expect(getConsumedPaymentsCount()).toBe(0)
+    })
+  })
+
+  describe('Concurrency Protection', () => {
+    it('ensures only one request succeeds among parallel concurrent calls for the same payload', async () => {
+      const header = Buffer.from(JSON.stringify({ transactionHash: 'tx_concurrent' })).toString('base64')
+
+      const attempts = Array.from({ length: 20 }, () =>
+        Promise.resolve().then(() => consumePaymentPayload(header))
+      )
+
+      const results = await Promise.all(attempts)
+
+      const successes = results.filter((r) => r.ok)
+      const failures = results.filter((r) => !r.ok)
+
+      expect(successes).toHaveLength(1)
+      expect(failures).toHaveLength(19)
+    })
+  })
+})

--- a/src/lib/paymentIntegrity.ts
+++ b/src/lib/paymentIntegrity.ts
@@ -1,0 +1,132 @@
+import crypto from 'crypto'
+
+/**
+ * Default validity window for consumed payment payloads in milliseconds.
+ * Aligned with x402 maxTimeoutSeconds (300 seconds = 5 minutes).
+ */
+export const DEFAULT_PAYMENT_VALIDITY_WINDOW_MS = 300 * 1000
+
+export interface ConsumedPayment {
+  consumedAt: number
+  expiresAt: number
+}
+
+// In-memory store for consumed payment identifiers and their expiration timestamps
+const consumedPayments = new Map<string, ConsumedPayment>()
+
+/**
+ * Periodically purge expired payment entries to prevent memory leaks.
+ */
+export function cleanupExpiredPayments(now: number = Date.now()): void {
+  for (const [id, record] of consumedPayments.entries()) {
+    if (record.expiresAt <= now) {
+      consumedPayments.delete(id)
+    }
+  }
+}
+
+/**
+ * Resets the consumed payment store. Essential for clean test isolation.
+ */
+export function resetConsumedPayments(): void {
+  consumedPayments.clear()
+}
+
+/**
+ * Returns the current size of the consumed payments cache (useful for diagnostic tests).
+ */
+export function getConsumedPaymentsCount(): number {
+  return consumedPayments.size
+}
+
+/**
+ * Extracts a unique, deterministic payment identifier from a payment header string or object.
+ *
+ * Checks if the header contains structured JSON with a transaction hash/id/signature.
+ * If no explicit ID field is found, computes a SHA-256 hash of the normalized header string.
+ */
+export function extractPaymentIdentifier(header: unknown): string | null {
+  if (!header || (typeof header !== 'string' && typeof header !== 'object')) {
+    return null
+  }
+
+  const rawString = typeof header === 'string' ? header.trim() : JSON.stringify(header)
+  if (!rawString) return null
+
+  // 1. Try parsing JSON (or base64-decoded JSON)
+  let obj: any = null
+  if (typeof header === 'object') {
+    obj = header
+  } else {
+    try {
+      obj = JSON.parse(rawString)
+    } catch {
+      try {
+        const decoded = Buffer.from(rawString, 'base64').toString('utf8')
+        obj = JSON.parse(decoded)
+      } catch {
+        // Raw non-JSON string
+      }
+    }
+  }
+
+  if (obj && typeof obj === 'object') {
+    const explicitId =
+      obj.transactionHash ||
+      obj.txHash ||
+      obj.transaction_hash ||
+      obj.signature ||
+      obj.id ||
+      obj.nonce ||
+      obj.paymentId
+    if (typeof explicitId === 'string' && explicitId.trim()) {
+      return `tx:${explicitId.trim()}`
+    }
+  }
+
+  // 2. Fallback: SHA-256 hash of the raw header string
+  const hash = crypto.createHash('sha256').update(rawString).digest('hex')
+  return `hash:${hash}`
+}
+
+/**
+ * Attempts to consume a payment identifier for its validity window.
+ * Returns { ok: true, paymentId } if the payment payload was successfully consumed (first time).
+ * Returns { ok: false, error, paymentId } if the payment payload has already been consumed within its validity window.
+ */
+export function consumePaymentPayload(
+  header: unknown,
+  validityWindowMs: number = DEFAULT_PAYMENT_VALIDITY_WINDOW_MS,
+  now: number = Date.now()
+): { ok: true; paymentId: string } | { ok: false; error: string; paymentId: string | null } {
+  cleanupExpiredPayments(now)
+
+  const paymentId = extractPaymentIdentifier(header)
+  if (!paymentId) {
+    return { ok: false, error: 'Invalid or missing payment header', paymentId: null }
+  }
+
+  const existing = consumedPayments.get(paymentId)
+  if (existing && existing.expiresAt > now) {
+    return { ok: false, error: 'Payment payload already consumed', paymentId }
+  }
+
+  // Atomically mark as consumed
+  consumedPayments.set(paymentId, {
+    consumedAt: now,
+    expiresAt: now + validityWindowMs,
+  })
+
+  return { ok: true, paymentId }
+}
+
+/**
+ * Returns whether a payment identifier is currently marked as consumed within its validity window.
+ */
+export function isPaymentConsumed(header: unknown, now: number = Date.now()): boolean {
+  cleanupExpiredPayments(now)
+  const paymentId = extractPaymentIdentifier(header)
+  if (!paymentId) return false
+  const existing = consumedPayments.get(paymentId)
+  return !!(existing && existing.expiresAt > now)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,19 +24,18 @@ export default defineConfig({
         'vitest.setup.ts',
       ],
       thresholds: {
-        statements: 25,
-        branches: 23,
-        functions: 20,
-        lines: 26,
+        statements: 35,
+        branches: 30,
+        functions: 28,
+        lines: 35,
         // Critical modules ratchet upward — keep Express, Vercel, browser, and MCP aligned
         // Bump these as coverage improves; CI fails if a PR drops below the ratchet.
-        // Global thresholds ratchet from 15 → 25 → 35 as payment/wallet/API/MCP/UI tests land.
-        // Current global ~28% (114 tests); next ratchet targets 35/30/28/35.
         'src/lib/constants.ts': { statements: 90, branches: 60, functions: 100, lines: 90 },
         'src/lib/stellar.ts': { statements: 85, branches: 75, functions: 85, lines: 85 },
+        'src/lib/paymentIntegrity.ts': { statements: 90, branches: 85, functions: 95, lines: 90 },
         'server/corsConfig.ts': { statements: 90, branches: 85, functions: 95, lines: 90 },
         'src/components/search/SearchBar.tsx': { statements: 80, branches: 80, functions: 90, lines: 80 },
-        'server/index.ts': { statements: 35, branches: 30, functions: 35, lines: 35 },
+        'server/index.ts': { statements: 65, branches: 60, functions: 65, lines: 65 },
         'api/search.ts': { statements: 90, branches: 75, functions: 80, lines: 90 },
         'api/health.ts': { statements: 80, branches: 50, functions: 100, lines: 80 },
         'mcp-server/index.ts': { statements: 30, branches: 20, functions: 20, lines: 30 },


### PR DESCRIPTION
Closes #112 

## Summary

This PR resolves an x402 security vulnerability where a single captured valid payment header (`X-Payment` / `payment-signature`) could potentially authorize multiple paid provider calls beyond the intended scheme semantics. 

We introduce stateful payment payload invalidation and concurrency locking across both Express (`server/index.ts`) and Vercel (`api/search.ts`) runtime boundaries.

---

## 🎯 Acceptance Criteria Satisfied

- [x] **Consumed Payment Rejection**: Consumed payment identifiers are tracked and rejected with HTTP `402 Payment Required` (`Payment payload already consumed`) within a 300-second validity window matching `maxTimeoutSeconds`.
- [x] **Concurrency Protection**: Parallel requests reusing the exact same payment payload are throttled so **only one** search query proceeds to the upstream provider (Serper.dev), while all concurrent duplicates are rejected.
- [x] **Runtime Boundary Alignment**: Payment settlement semantics (`amount=10000 stroops` -> `0.001 USDC`, `scheme=exact`, `asset=C...`, `network=stellar:testnet|mainnet`) remain 100% aligned across Express, Vercel, browser, and MCP tools.
- [x] **Automated Coverage & Documentation**: Updated technical documentation in `README.md` and `CONTRIBUTING.md`, added unit and integration test suites (`src/lib/paymentIntegrity.test.ts`, `server/payment.test.ts`), and ratcheted Vitest coverage gates in `vite.config.ts`.

---

## 🛠️ Key Implementation Details

1. **`src/lib/paymentIntegrity.ts`**:
   - `extractPaymentIdentifier()`: Deterministically extracts explicit transaction identifiers (`transactionHash`, `txHash`, `signature`, `id`, `nonce`) or computes a SHA-256 fallback hash for raw signature tokens.
   - `consumePaymentPayload()`: Performs atomic reservation of payment identifiers with automated TTL cleanup (`cleanupExpiredPayments()`) for a 300-second validity window (`DEFAULT_PAYMENT_VALIDITY_WINDOW_MS = 300000`).
   - `resetConsumedPayments()`: Exposes reset utilities for clean test isolation.

2. **Express & Vercel Integration**:
   - **Express (`server/index.ts`)**: Added `paymentIntegrityMiddleware` after `paymentMiddlewareFromConfig` to protect `/search`, `/images`, and `/news` endpoints.
   - **Vercel (`api/search.ts`)**: Integrated `consumePaymentPayload` directly into the serverless function handler pipeline.
   - **Environment Guard**: Updated `server/index.ts` start condition to prevent `EADDRINUSE` port binding conflicts during parallel test execution (`NODE_ENV !== 'test'`).

3. **Coverage Ratchet**:
   - Added `src/lib/paymentIntegrity.ts` ratchet threshold: Statements 90%, Branches 85%, Functions 95%, Lines 90%.
   - Ratcheted `server/index.ts` coverage threshold from 35% to 65%.
   - Ratcheted global coverage thresholds from 25/23/20/26 to **35% Statements, 30% Branches, 28% Functions, 35% Lines**.

---

## 🧪 Verification & Test Results

All 13 test files and 166 unit/concurrency tests passed with zero TypeScript or ESLint errors:

```bash
npm run typecheck      # 0 errors
npm run lint           # 0 errors
npm run test:coverage  # 13 passed, 166 passed, exit code 0
