### PR TITLE
ci: configure dependabot for npm and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      lint-and-tooling:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "typescript"
+          - "@types/*"
+          - "globals"
+          - "tsx"
+          - "postcss*"
+          - "autoprefixer"
+          - "tailwindcss"
+          - "concurrently"
+      test-dependencies:
+        patterns:
+          - "vitest*"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "supertest"
+          - "@types/supertest"
+          - "jsdom"
+      frontend-ui:
+        patterns:
+          - "lucide-react"
+          - "clsx"
+          - "sonner"
+          - "recharts"
+          - "@types/recharts"
+          - "framer-motion"
+        update-types:
+          - "minor"
+          - "patch"
+      stellar-and-payment-minor-patch:
+        patterns:
+          - "@stellar/*"
+          - "@x402/*"
+          - "@modelcontextprotocol/*"
+          - "groq-sdk"
+        update-types:
+          - "minor"
+          - "patch"
+      server-runtime-minor-patch:
+        patterns:
+          - "express*"
+          - "@types/express*"
+          - "cors"
+          - "@types/cors"
+          - "helmet"
+          - "winston"
+          - "dotenv"
+          - "@vercel/node"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,6 +284,12 @@ Closes #9
 docs: add CONTRIBUTING.md
 ```
 
+### Dependency updates (Dependabot)
+
+Dependabot is configured in `.github/dependabot.yml` to automatically propose weekly updates with sensible open PR limits:
+- **Grouped updates:** Minor/patch dependencies for tooling, linting, testing, and UI are grouped into single PRs to reduce notification noise.
+- **Deliberate review for payment & runtime:** Major upgrades for `@x402/*`, `@stellar/*`, `@modelcontextprotocol/*`, AI SDKs (`groq-sdk`), and server runtime packages are kept as isolated PRs to ensure deliberate review, preventing regressions across runtime boundaries (Express, Vercel, browser, and MCP) and safeguarding x402 settlement semantics.
+
 ---
 
 ## Submitting a Pull Request


### PR DESCRIPTION
### What changed
- Added `.github/dependabot.yml` configuring weekly automated updates for `npm` and `github-actions`.
- Configured grouped updates with sensible limits for linting, testing, and UI packages.
- Isolated major version updates for payment (`@x402/*`, `@stellar/*`), MCP, AI SDKs, and server runtimes into dedicated PRs.
- Updated `CONTRIBUTING.md` to document the Dependabot scheduling and review policy.

### Why it changed
- Keeps fast-moving Stellar, x402, MCP, Vite, and AI dependencies up to date with reduced notification noise while ensuring high-risk major payment/runtime upgrades receive deliberate review.

### How it was verified
- Validated YAML schema and group configurations in `.github/dependabot.yml`.
- Verified documentation alignment in `CONTRIBUTING.md`.

Closes #203
