### PR TITLE
Fix groq assistant accessibility

### DIFF
--- a/src/components/ai/GroqAssistant.tsx
+++ b/src/components/ai/GroqAssistant.tsx
@@ -245,9 +245,10 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
             initial={{ opacity: 0, y: 20, scale: 0.95 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 20, scale: 0.95 }}
-            className="fixed bottom-20 right-6 z-40 w-96 rounded-2xl overflow-hidden flex flex-col"
+            className="fixed bottom-20 right-4 left-4 sm:left-auto sm:right-6 z-40 sm:w-96 rounded-2xl overflow-hidden flex flex-col"
             style={{
               height: '480px',
+              maxHeight: 'calc(100dvh - 6rem)',
               background: 'rgba(6,13,20,0.96)',
               border: '1px solid rgba(0,245,255,0.2)',
               backdropFilter: 'blur(20px)',


### PR DESCRIPTION
Closes #153 

Changes made
Changed the fixed width w-96 and right-6 to adapt to smaller screens (right-4 left-4 sm:left-auto sm:right-6 sm:w-96).
Used dynamic viewport dimensions maxHeight: 'calc(100dvh - 6rem)' so the panel resizes perfectly to keep the message input completely visible even when the mobile device's on-screen keyboard is active.
There are no direct automated tests or documentation requiring updates for this purely UI-level sizing change, and no backend or payment routes were modified, preserving Express, Vercel, MCP, and x402 behaviors.