### PR TITLE
fix(api): standardize method handling and Allow headers across all en…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ To guarantee that each payment identifier authorizes **exactly one provider call
 - **Payload Invalidation:** Extracts transaction hashes (or SHA-256 fallback hashes of payment headers) and invalidates consumed payloads for a 300-second window.
 - **Concurrency Throttling:** Rapid parallel requests using identical payment payloads are throttled so only one search query proceeds; concurrent duplicates immediately receive HTTP 402 (`Payment payload already consumed`).
 
+### Method Handling & Allow Headers
+
+Every endpoint explicitly handles `OPTIONS` (preflight) and returns `405 Method Not Allowed` with a correct `Allow` header for unsupported methods. This keeps Express, Vercel, browser, and MCP behaviour aligned:
+
+| Endpoint | Allowed Methods |
+|---|---|
+| `GET /search` | `GET, OPTIONS` |
+| `GET /images` | `GET, OPTIONS` |
+| `GET /news` | `GET, OPTIONS` |
+| `GET /health` | `GET, OPTIONS` |
+| `POST /ai/chat` | `POST, OPTIONS` |
+| `GET /` | `GET, OPTIONS` |
+
+405 responses include a common error body: `{ "error": "Method not allowed" }`.
+
 ### Sequence diagram
 
 ```mermaid

--- a/api/ai/chat.ts
+++ b/api/ai/chat.ts
@@ -4,7 +4,13 @@ import Groq from 'groq-sdk'
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! })
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // ─── Method handling ───────────────────────────────────────────────────
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'POST, OPTIONS')
+    return res.status(200).end()
+  }
   if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS')
     return res.status(405).json({ error: 'Method not allowed' })
   }
 

--- a/api/health.test.ts
+++ b/api/health.test.ts
@@ -71,4 +71,24 @@ describe('api/health — Vercel health aligned with server /health', () => {
     const payload = res.json.mock.calls[0][0]
     expect(payload.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
+
+  it('handles OPTIONS preflight with Allow header', async () => {
+    const req: any = { method: 'OPTIONS', headers: {} }
+    const res = mockRes()
+    await handler(req, res)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', 'GET, OPTIONS')
+    expect(res.end).toHaveBeenCalled()
+  })
+
+  it('returns 405 with Allow header for unsupported methods', async () => {
+    for (const method of ['POST', 'PUT', 'DELETE', 'PATCH']) {
+      const req: any = { method, headers: {} }
+      const res = mockRes()
+      await handler(req, res)
+      expect(res.status).toHaveBeenCalledWith(405)
+      expect(res.setHeader).toHaveBeenCalledWith('Allow', 'GET, OPTIONS')
+      expect(res.json).toHaveBeenCalledWith({ error: 'Method not allowed' })
+    }
+  })
 })

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,6 +1,16 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
+  // ─── Method handling ───────────────────────────────────────────────────
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'GET, OPTIONS')
+    return res.status(200).end()
+  }
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET, OPTIONS')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
   const NETWORK = process.env.STELLAR_NETWORK || 'stellar:testnet'
   const FACILITATOR_URL = process.env.FACILITATOR_URL || 'https://www.x402.org/facilitator'
   const SERPER_API_KEY = process.env.SERPER_API_KEY

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,6 +1,16 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
+  // ─── Method handling ───────────────────────────────────────────────────
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'GET, OPTIONS')
+    return res.status(200).end()
+  }
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET, OPTIONS')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
   res.json({
     name: 'StellarSearch',
     version: '1.0.0',

--- a/api/search.test.ts
+++ b/api/search.test.ts
@@ -50,18 +50,20 @@ describe('api/search — Vercel x402 settlement (aligned with Express)', () => {
     global.fetch = originalFetch
   })
 
-  it('handles OPTIONS preflight', async () => {
+  it('handles OPTIONS preflight with Allow header', async () => {
     const { req, res } = mockReqRes({ method: 'OPTIONS' })
     await handler(req, res)
     expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', 'GET, OPTIONS')
     expect(res.end).toHaveBeenCalled()
   })
 
-  it('rejects non-GET methods', async () => {
+  it('rejects non-GET methods with Allow header', async () => {
     const { req, res } = mockReqRes({ method: 'POST' })
     await handler(req, res)
     expect(res._status).toBe(405)
     expect(res._json.error).toMatch(/Method not allowed/)
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', 'GET, OPTIONS')
   })
 
   it('rejects missing q', async () => {

--- a/api/search.ts
+++ b/api/search.ts
@@ -30,8 +30,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     'X-Payment-Response',
   ].join(', '))
 
-  if (req.method === 'OPTIONS') return res.status(200).end()
-  if (req.method !== 'GET')    return res.status(405).json({ error: 'Method not allowed' })
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'GET, OPTIONS')
+    return res.status(200).end()
+  }
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET, OPTIONS')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
 
   const { q, count = '5', freshness } = req.query as Record<string, string>
 

--- a/server/health.test.ts
+++ b/server/health.test.ts
@@ -94,6 +94,62 @@ describe('POST /ai/chat validation', () => {
   })
 })
 
+describe('method handling — 405 with Allow header', () => {
+  it('GET /search returns 405 with Allow header for POST', async () => {
+    const res = await request(app).post('/search')
+    expect(res.status).toBe(405)
+    expect(res.body.error).toMatch(/Method not allowed/)
+    expect(res.headers['allow']).toMatch(/GET/)
+    expect(res.headers['allow']).toMatch(/OPTIONS/)
+  })
+
+  it('GET /search returns 405 with Allow header for PUT', async () => {
+    const res = await request(app).put('/search')
+    expect(res.status).toBe(405)
+    expect(res.headers['allow']).toMatch(/GET/)
+  })
+
+  it('GET /images returns 405 with Allow header for POST', async () => {
+    const res = await request(app).post('/images')
+    expect(res.status).toBe(405)
+    expect(res.body.error).toMatch(/Method not allowed/)
+    expect(res.headers['allow']).toMatch(/GET/)
+  })
+
+  it('GET /news returns 405 with Allow header for DELETE', async () => {
+    const res = await request(app).delete('/news')
+    expect(res.status).toBe(405)
+    expect(res.headers['allow']).toMatch(/GET/)
+  })
+
+  it('GET /health returns 405 with Allow header for POST', async () => {
+    const res = await request(app).post('/health')
+    expect(res.status).toBe(405)
+    expect(res.body.error).toMatch(/Method not allowed/)
+    expect(res.headers['allow']).toMatch(/GET/)
+  })
+
+  it('POST /ai/chat returns 405 with Allow header for GET', async () => {
+    const res = await request(app).get('/ai/chat')
+    expect(res.status).toBe(405)
+    expect(res.body.error).toMatch(/Method not allowed/)
+    expect(res.headers['allow']).toMatch(/POST/)
+  })
+
+  it('POST /ai/chat returns 405 with Allow header for DELETE', async () => {
+    const res = await request(app).delete('/ai/chat')
+    expect(res.status).toBe(405)
+    expect(res.headers['allow']).toMatch(/POST/)
+  })
+
+  it('GET / returns 405 with Allow header for POST', async () => {
+    const res = await request(app).post('/')
+    expect(res.status).toBe(405)
+    expect(res.body.error).toMatch(/Method not allowed/)
+    expect(res.headers['allow']).toMatch(/GET/)
+  })
+})
+
 describe('GET /search validation (x402 middleware bypassed via mock)', () => {
   it('returns 400 when q missing', async () => {
     const res = await request(app).get('/search')

--- a/server/index.ts
+++ b/server/index.ts
@@ -37,6 +37,22 @@ const app  = express()
 const PORT = process.env.PORT || 3001
 const RATE_LIMIT_PER_MINUTE = parseInt(process.env.RATE_LIMIT_PER_MINUTE || '30', 10)
 
+// ─── Method handling helpers ─────────────────────────────────────────────
+// Centralises OPTIONS preflight and 405 responses so every Express endpoint
+// advertises the correct Allow header and returns a consistent error body.
+// These keep Express, Vercel, browser, and MCP behaviour aligned.
+
+/** Build a comma-separated Allow header from a list of methods. */
+function allowHeader(...methods: string[]): string {
+  return [...new Set(['OPTIONS', ...methods])].join(', ')
+}
+
+/** Respond with 405 + Allow header + common error body. */
+function methodNotAllowed(res: Response, allow: string): void {
+  res.setHeader('Allow', allow)
+  res.status(405).json({ error: 'Method not allowed' })
+}
+
 const limiter = rateLimit({
   windowMs: 60 * 1000,
   max: RATE_LIMIT_PER_MINUTE,
@@ -201,6 +217,8 @@ export function validateQuery(
 
 // ─── GET /search ──────────────────────────────────────────────────────────
 app.get('/search', async (req: Request, res: Response) => {
+  // Explicit method guard — unsupported methods receive 405 + Allow header
+  if (req.method !== 'GET') return methodNotAllowed(res, allowHeader('GET'))
   const { q, count = '5', freshness } = req.query as Record<string, string>
 
   const v = validateQuery(q)
@@ -310,6 +328,8 @@ app.get('/search', async (req: Request, res: Response) => {
 
 // ─── GET /images ──────────────────────────────────────────────────────────
 app.get('/images', async (req: Request, res: Response) => {
+  // Explicit method guard — unsupported methods receive 405 + Allow header
+  if (req.method !== 'GET') return methodNotAllowed(res, allowHeader('GET'))
   const { q, count = '10' } = req.query as Record<string, string>
 
   const v = validateQuery(q)
@@ -376,6 +396,8 @@ app.get('/images', async (req: Request, res: Response) => {
 
 // ─── GET /news ────────────────────────────────────────────────────────────
 app.get('/news', async (req: Request, res: Response) => {
+  // Explicit method guard — unsupported methods receive 405 + Allow header
+  if (req.method !== 'GET') return methodNotAllowed(res, allowHeader('GET'))
   const { q, count = '10', freshness } = req.query as Record<string, string>
 
   const v = validateQuery(q)
@@ -453,7 +475,9 @@ app.get('/news', async (req: Request, res: Response) => {
 })
 
 // ─── GET /health ──────────────────────────────────────────────────────────
-app.get('/health', (_req: Request, res: Response) => {
+app.get('/health', (req: Request, res: Response) => {
+  // Explicit method guard — unsupported methods receive 405 + Allow header
+  if (req.method !== 'GET') return methodNotAllowed(res, allowHeader('GET'))
   const avg = stats.latencies.length
     ? Math.round(stats.latencies.reduce((a, b) => a + b, 0) / stats.latencies.length)
     : 0
@@ -482,6 +506,8 @@ app.get('/health', (_req: Request, res: Response) => {
 // `Accept: text/event-stream`; otherwise returns the full completion as JSON
 // (back-compat fallback for callers that don't support SSE).
 app.post('/ai/chat', async (req: Request, res: Response) => {
+  // Explicit method guard — unsupported methods receive 405 + Allow header
+  if (req.method !== 'POST') return methodNotAllowed(res, allowHeader('POST'))
   const { messages, model: requestedModel } = req.body as {
     messages: { role: 'system' | 'user' | 'assistant'; content: string }[]
     model?: string
@@ -580,7 +606,9 @@ app.post('/ai/chat', async (req: Request, res: Response) => {
 
 
 // ─── GET / ────────────────────────────────────────────────────────────────
-app.get('/', (_req: Request, res: Response) => {
+app.get('/', (req: Request, res: Response) => {
+  // Explicit method guard — unsupported methods receive 405 + Allow header
+  if (req.method !== 'GET') return methodNotAllowed(res, allowHeader('GET'))
   res.json({
     name:        'StellarSearch',
     version:     '1.0.0',
@@ -593,6 +621,28 @@ app.get('/', (_req: Request, res: Response) => {
       'GET /health':           'Live server stats',
     },
   })
+})
+
+// ─── Catch-all: unsupported methods → 405 with Allow header ──────────────
+// Placed after all route definitions. Express routes only register for the
+// explicit method (get/post), so any other method falls through to here.
+app.all('/search', (req: Request, res: Response) => {
+  methodNotAllowed(res, allowHeader('GET'))
+})
+app.all('/images', (req: Request, res: Response) => {
+  methodNotAllowed(res, allowHeader('GET'))
+})
+app.all('/news', (req: Request, res: Response) => {
+  methodNotAllowed(res, allowHeader('GET'))
+})
+app.all('/health', (req: Request, res: Response) => {
+  methodNotAllowed(res, allowHeader('GET'))
+})
+app.all('/ai/chat', (req: Request, res: Response) => {
+  methodNotAllowed(res, allowHeader('POST'))
+})
+app.all('/', (req: Request, res: Response) => {
+  methodNotAllowed(res, allowHeader('GET'))
 })
 
 // ─── Start ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary

Standardized HTTP method handling across the Express and Vercel API endpoints by adding explicit OPTIONS preflight handling and consistent 405 Method Not Allowed responses with accurate Allow headers.

Changes

Express (server/index.ts)

* Added shared allowHeader() and methodNotAllowed() helpers.
* Added method guards for:
    * GET /search
    * GET /images
    * GET /news
    * GET /health
    * GET /
    * POST /ai/chat
* Added app.all() catch-all handlers to consistently return 405 responses with the appropriate Allow header.

Vercel API handlers

* api/health.ts — Added OPTIONS preflight and 405 handling with Allow.
* api/ai/chat.ts — Added OPTIONS preflight and Allow to the existing 405 response.
* api/index.ts — Added OPTIONS preflight and 405 handling with Allow.
* api/search.ts — Added Allow headers to existing OPTIONS and 405 responses.

Tests & Documentation

* Updated method-handling coverage in:
    * server/health.test.ts
    * api/health.test.ts
    * api/search.test.ts
* Updated README.md to document the standardized behavior.

Compatibility

The changes keep method handling consistent across Express, Vercel, browser, and MCP environments while preserving the existing verified x402 settlement semantics.

Issue

Closes #100