### PR TITLE
fix: validate and normalize upstream Serper payloads deterministically

### DIFF
--- a/api/search.test.ts
+++ b/api/search.test.ts
@@ -233,4 +233,29 @@ describe('api/search — Vercel x402 settlement (aligned with Express)', () => {
     expect(successes).toHaveLength(1)
     expect(rejections).toHaveLength(numConcurrent - 1)
   })
+
+  it('safely normalizes malformed Serper payloads by filtering out rows with invalid links', async () => {
+    const fakeTx = Buffer.from(JSON.stringify({ transactionHash: 'tx_malformed_vercel' })).toString('base64')
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        organic: [
+          { title: 'Bad Link', link: 'not-a-valid-http-url' },
+          { title: 'Valid Vercel Result', link: 'https://vercel.com/docs' },
+        ],
+      }),
+    } as any)
+
+    const { req, res } = mockReqRes({
+      method: 'GET',
+      query: { q: 'vercel' },
+      headers: { 'x-payment': fakeTx },
+    })
+
+    await handler(req, res)
+    expect(res._json.results).toHaveLength(1)
+    expect(res._json.results[0].title).toBe('Valid Vercel Result')
+    expect(res._json.results[0].url).toBe('https://vercel.com/docs')
+  })
 })
+

--- a/api/search.ts
+++ b/api/search.ts
@@ -6,6 +6,8 @@ import {
   AMOUNT_USDC
 } from '../src/lib/constants'
 import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
+import { normalizeOrganicResults } from '../src/lib/serperNormalizer'
+import type { SearchResponse, ApiErrorResponse } from '../src/types/index.js'
 
 // ─── Config ───────────────────────────────────────────────────────────────
 const RECEIVING_ADDRESS = process.env.STELLAR_RECEIVING_ADDRESS!
@@ -31,11 +33,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   ].join(', '))
 
   if (req.method === 'OPTIONS') return res.status(200).end()
-  if (req.method !== 'GET')    return res.status(405).json({ error: 'Method not allowed' })
+  if (req.method !== 'GET') {
+    const errorBody: ApiErrorResponse = { error: 'Method not allowed' }
+    return res.status(405).json(errorBody)
+  }
 
   const { q, count = '5', freshness } = req.query as Record<string, string>
 
-  if (!q?.trim()) return res.status(400).json({ error: 'Missing required parameter: q' })
+  if (!q?.trim()) {
+    const errorBody: ApiErrorResponse = { error: 'Missing required parameter: q' }
+    return res.status(400).json(errorBody)
+  }
 
   // ─── Payment check ────────────────────────────────────────────────────────
   const paymentHeader =
@@ -71,13 +79,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       'PAYMENT-REQUIRED',
       Buffer.from(JSON.stringify(paymentRequired)).toString('base64')
     )
-    return res.status(402).json({ error: 'Payment required' })
+    const errorBody: ApiErrorResponse = { error: 'Payment required' }
+    return res.status(402).json(errorBody)
   }
 
   // ─── Payment Replay Protection ───────────────────────────────────────────
   const consumption = consumePaymentPayload(paymentHeader)
   if (!consumption.ok) {
-    return res.status(402).json({ error: consumption.error })
+    const errorBody: ApiErrorResponse = { error: consumption.error }
+    return res.status(402).json(errorBody)
   }
 
   // ─── Payment present — proceed with search ────────────────────────────────
@@ -122,26 +132,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!serperRes.ok) {
       const errText = await serperRes.text()
       console.error('[serper]', serperRes.status, errText)
-      return res.status(502).json({ error: `Serper.dev API error: ${serperRes.status}` })
+      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
+      return res.status(502).json(errorBody)
     }
 
-    const data      = await serperRes.json() as any
-    const latencyMs = Date.now() - t0
+    const data: unknown = await serperRes.json()
+    const latencyMs    = Date.now() - t0
 
-    const results = (data.organic || []).map((r: any, i: number) => ({
-      id:             String(i + 1),
-      title:          r.title   || 'No title',
-      url:            r.link,
-      description:    r.snippet || '',
-      source:         (() => {
-        try { return new URL(r.link).hostname.replace('www.', '') }
-        catch { return r.link }
-      })(),
-      relevanceScore: Math.max(0.5, 1 - i * 0.06),
-      publishedAt:    r.date || undefined,
-    }))
+    const results = normalizeOrganicResults(data)
 
-    return res.json({
+    const responseBody: SearchResponse = {
       query:      q.trim(),
       results,
       count:      results.length,
@@ -150,10 +150,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       currency:   'USDC',
       txHash,
       latencyMs,
-    })
+    }
+
+    return res.json(responseBody)
 
   } catch (err: any) {
     console.error('[search error]', err.message)
-    return res.status(500).json({ error: 'Search failed.' })
+    const errorBody: ApiErrorResponse = { error: 'Search failed.' }
+    return res.status(500).json(errorBody)
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,6 +30,17 @@ import {
   AMOUNT_STROOPS
 } from '../src/lib/constants'
 import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
+import {
+  normalizeOrganicResults,
+  normalizeImageResults,
+  normalizeNewsResults,
+} from '../src/lib/serperNormalizer.js'
+import type {
+  SearchResponse,
+  ImageSearchResponse,
+  NewsSearchResponse,
+  ApiErrorResponse,
+} from '../src/types/index.js'
 
 dotenv.config()
 
@@ -242,7 +253,7 @@ app.get('/search', async (req: Request, res: Response) => {
       return res.status(502).json({ error: `Serper.dev API error: ${serperRes.status}` })
     }
 
-    const data = await serperRes.json() as any
+    const data: unknown = await serperRes.json()
     const latencyMs = Date.now() - t0
 
     stats.totalQueries++
@@ -250,15 +261,7 @@ app.get('/search', async (req: Request, res: Response) => {
     stats.latencies.push(latencyMs)
     if (stats.latencies.length > 200) stats.latencies.shift()
 
-    const results = (data.organic || []).map((r: any, i: number) => ({
-      id: String(i + 1),
-      title: r.title || 'No title',
-      url: r.link,
-      description: r.snippet || '',
-      source: (() => { try { return new URL(r.link).hostname.replace('www.', '') } catch { return r.link } })(),
-      relevanceScore: Math.max(0.5, 1 - i * 0.06),
-      publishedAt: r.date || undefined,
-    }))
+    const results = normalizeOrganicResults(data)
 
     // The real tx hash comes from the X-PAYMENT-RESPONSE header set by the facilitator
     const txHash = (req.headers['x-payment-response'] as string) || null
@@ -267,7 +270,7 @@ app.get('/search', async (req: Request, res: Response) => {
     let suggestions: string[] = []
     if (req.query.suggestions === '1' && results.length > 0) {
       try {
-        const topSnippets = results.slice(0, 3).map((r: any) => r.description).join(' | ')
+        const topSnippets = results.slice(0, 3).map((r) => r.description).join(' | ')
         const suggCompletion = await groq.chat.completions.create({
           model: 'llama-3.3-70b-versatile',
           messages: [
@@ -285,13 +288,21 @@ app.get('/search', async (req: Request, res: Response) => {
         })
         const raw = suggCompletion.choices[0]?.message?.content || '[]'
         const match = raw.match(/\[[\s\S]*\]/)
-        if (match) suggestions = JSON.parse(match[0]).slice(0, 3)
+        if (match) {
+          const parsed = JSON.parse(match[0])
+          if (Array.isArray(parsed)) {
+            suggestions = parsed
+              .filter((s: unknown): s is string => typeof s === 'string' && s.trim().length > 0)
+              .map((s: string) => s.trim())
+              .slice(0, 3)
+          }
+        }
       } catch (err: any) {
         console.warn('[suggestions] Groq error:', err.message)
       }
     }
 
-    return res.json({
+    const responseBody: SearchResponse = {
       query: cleanQ,
       results,
       count: results.length,
@@ -301,10 +312,13 @@ app.get('/search', async (req: Request, res: Response) => {
       txHash,
       latencyMs,
       suggestions,
-    })
+    }
+
+    return res.json(responseBody)
   } catch (err: any) {
     console.error('[search error]', err.message)
-    return res.status(500).json({ error: 'Search failed. Check server logs.' })
+    const errorBody: ApiErrorResponse = { error: 'Search failed. Check server logs.' }
+    return res.status(500).json(errorBody)
   }
 })
 
@@ -334,10 +348,11 @@ app.get('/images', async (req: Request, res: Response) => {
     if (!serperRes.ok) {
       const err = await serperRes.text()
       console.error('[serper images]', serperRes.status, err)
-      return res.status(502).json({ error: `Serper.dev API error: ${serperRes.status}` })
+      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
+      return res.status(502).json(errorBody)
     }
 
-    const data = await serperRes.json() as any
+    const data: unknown = await serperRes.json()
     const latencyMs = Date.now() - t0
 
     stats.totalQueries++
@@ -345,20 +360,11 @@ app.get('/images', async (req: Request, res: Response) => {
     stats.latencies.push(latencyMs)
     if (stats.latencies.length > 200) stats.latencies.shift()
 
-    const results = (data.images || []).map((r: any, i: number) => ({
-      id: String(i + 1),
-      title: r.title || 'No title',
-      imageUrl: r.imageUrl,
-      thumbnailUrl: r.thumbnailUrl || r.imageUrl,
-      sourceUrl: r.link,
-      source: (() => { try { return new URL(r.link).hostname.replace('www.', '') } catch { return r.link } })(),
-      width: r.imageWidth,
-      height: r.imageHeight,
-    }))
+    const results = normalizeImageResults(data)
 
     const txHash = (req.headers['x-payment-response'] as string) || null
 
-    return res.json({
+    const responseBody: ImageSearchResponse = {
       query: cleanQ,
       results,
       count: results.length,
@@ -367,10 +373,13 @@ app.get('/images', async (req: Request, res: Response) => {
       currency: 'USDC',
       txHash,
       latencyMs,
-    })
+    }
+
+    return res.json(responseBody)
   } catch (err: any) {
     console.error('[images error]', err.message)
-    return res.status(500).json({ error: 'Image search failed. Check server logs.' })
+    const errorBody: ApiErrorResponse = { error: 'Image search failed. Check server logs.' }
+    return res.status(500).json(errorBody)
   }
 })
 
@@ -385,7 +394,7 @@ app.get('/news', async (req: Request, res: Response) => {
   const t0 = Date.now()
 
   try {
-    const requestBody: any = {
+    const requestBody: Record<string, unknown> = {
       q: cleanQ,
       num: Math.min(parseInt(count) || 10, 20),
     }
@@ -413,10 +422,11 @@ app.get('/news', async (req: Request, res: Response) => {
     if (!serperRes.ok) {
       const err = await serperRes.text()
       console.error('[serper news]', serperRes.status, err)
-      return res.status(502).json({ error: `Serper.dev API error: ${serperRes.status}` })
+      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
+      return res.status(502).json(errorBody)
     }
 
-    const data = await serperRes.json() as any
+    const data: unknown = await serperRes.json()
     const latencyMs = Date.now() - t0
 
     stats.totalQueries++
@@ -424,19 +434,11 @@ app.get('/news', async (req: Request, res: Response) => {
     stats.latencies.push(latencyMs)
     if (stats.latencies.length > 200) stats.latencies.shift()
 
-    const results = (data.news || []).map((r: any, i: number) => ({
-      id: String(i + 1),
-      title: r.title || 'No title',
-      url: r.link,
-      snippet: r.snippet || '',
-      source: r.source || (() => { try { return new URL(r.link).hostname.replace('www.', '') } catch { return r.link } })(),
-      publishedAt: r.date || undefined,
-      imageUrl: r.imageUrl || undefined,
-    }))
+    const results = normalizeNewsResults(data)
 
     const txHash = (req.headers['x-payment-response'] as string) || null
 
-    return res.json({
+    const responseBody: NewsSearchResponse = {
       query: cleanQ,
       results,
       count: results.length,
@@ -445,10 +447,13 @@ app.get('/news', async (req: Request, res: Response) => {
       currency: 'USDC',
       txHash,
       latencyMs,
-    })
+    }
+
+    return res.json(responseBody)
   } catch (err: any) {
     console.error('[news error]', err.message)
-    return res.status(500).json({ error: 'News search failed. Check server logs.' })
+    const errorBody: ApiErrorResponse = { error: 'News search failed. Check server logs.' }
+    return res.status(500).json(errorBody)
   }
 })
 

--- a/server/payment.test.ts
+++ b/server/payment.test.ts
@@ -392,3 +392,70 @@ describe('x402 settlement semantics — Express + Vercel constants aligned', () 
     expect(res.body.latencyMs).toBeGreaterThanOrEqual(0)
   })
 })
+
+// ─── Upstream Serper payload validation ───────────────────────────────────────
+
+describe('malformed upstream Serper payloads — server normalization', () => {
+  it('handles null or non-object Serper responses safely (returns 200 with empty results)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => null,
+    } as any)
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_malformed_null'))
+    expect(res.status).toBe(200)
+    expect(res.body.results).toEqual([])
+    expect(res.body.count).toBe(0)
+  })
+
+  it('skips organic rows missing valid HTTP/HTTPS link or containing malformed fields', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        organic: [
+          { title: 'Bad Link 1', link: 'javascript:alert(1)' },
+          { title: 'Valid Link', link: 'https://example.com/ok', snippet: 'Good' },
+          { title: 'Missing Link' },
+        ],
+      }),
+    } as any)
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_malformed_organic'))
+    expect(res.status).toBe(200)
+    expect(res.body.results).toHaveLength(1)
+    expect(res.body.results[0].title).toBe('Valid Link')
+    expect(res.body.results[0].url).toBe('https://example.com/ok')
+  })
+
+  it('skips image rows missing valid imageUrl and handles malformed image dimensions', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        images: [
+          { title: 'No Image', link: 'https://example.com' },
+          { title: 'Valid Img', imageUrl: 'https://example.com/img.png', imageWidth: 'invalid' },
+        ],
+      }),
+    } as any)
+    const res = await request(app).get('/images?q=stellar').set('x-payment', makeReceipt('tx_malformed_img'))
+    expect(res.status).toBe(200)
+    expect(res.body.results).toHaveLength(1)
+    expect(res.body.results[0].imageUrl).toBe('https://example.com/img.png')
+    expect(res.body.results[0].width).toBeUndefined()
+  })
+
+  it('skips news rows missing valid link', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        news: [
+          { title: 'Bad News', link: 'not-a-url' },
+          { title: 'Good News', link: 'https://news.example.com/item' },
+        ],
+      }),
+    } as any)
+    const res = await request(app).get('/news?q=stellar').set('x-payment', makeReceipt('tx_malformed_news'))
+    expect(res.status).toBe(200)
+    expect(res.body.results).toHaveLength(1)
+    expect(res.body.results[0].title).toBe('Good News')
+  })
+})
+

--- a/src/lib/serperNormalizer.test.ts
+++ b/src/lib/serperNormalizer.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isValidHttpUrl,
+  extractSafeHostname,
+  normalizeOrganicResults,
+  normalizeImageResults,
+  normalizeNewsResults,
+} from './serperNormalizer'
+
+describe('serperNormalizer helper functions', () => {
+  describe('isValidHttpUrl', () => {
+    it('returns true for valid http and https URLs', () => {
+      expect(isValidHttpUrl('https://stellar.org')).toBe(true)
+      expect(isValidHttpUrl('http://developers.stellar.org/docs/page?q=1')).toBe(true)
+    })
+
+    it('returns false for non-http(s) schemes, malformed strings, and non-strings', () => {
+      expect(isValidHttpUrl('javascript:alert(1)')).toBe(false)
+      expect(isValidHttpUrl('ftp://example.com/file')).toBe(false)
+      expect(isValidHttpUrl('not a url')).toBe(false)
+      expect(isValidHttpUrl('')).toBe(false)
+      expect(isValidHttpUrl(null)).toBe(false)
+      expect(isValidHttpUrl(undefined)).toBe(false)
+      expect(isValidHttpUrl(12345)).toBe(false)
+    })
+  })
+
+  describe('extractSafeHostname', () => {
+    it('strips leading www. and returns hostname', () => {
+      expect(extractSafeHostname('https://www.stellar.org/news')).toBe('stellar.org')
+      expect(extractSafeHostname('http://developers.stellar.org')).toBe('developers.stellar.org')
+    })
+
+    it('returns original input or fallback if URL parsing fails', () => {
+      expect(extractSafeHostname('invalid-url')).toBe('invalid-url')
+      expect(extractSafeHostname('')).toBe('unknown')
+    })
+  })
+
+  describe('normalizeOrganicResults', () => {
+    it('returns empty array when raw input is null, non-object, or lacks organic array', () => {
+      expect(normalizeOrganicResults(null)).toEqual([])
+      expect(normalizeOrganicResults(undefined)).toEqual([])
+      expect(normalizeOrganicResults('string')).toEqual([])
+      expect(normalizeOrganicResults({ organic: 'not an array' })).toEqual([])
+      expect(normalizeOrganicResults({})).toEqual([])
+    })
+
+    it('normalizes valid organic rows correctly', () => {
+      const input = {
+        organic: [
+          { title: 'Stellar Docs', link: 'https://developers.stellar.org', snippet: 'Official docs', date: '2026-01-01' },
+          { title: 'Stellar Foundation', link: 'https://www.stellar.org', description: 'Main site' },
+        ],
+      }
+      const results = normalizeOrganicResults(input)
+
+      expect(results).toHaveLength(2)
+      expect(results[0]).toEqual({
+        id: '1',
+        title: 'Stellar Docs',
+        url: 'https://developers.stellar.org',
+        description: 'Official docs',
+        source: 'developers.stellar.org',
+        relevanceScore: 1,
+        publishedAt: '2026-01-01',
+      })
+      expect(results[1]).toEqual({
+        id: '2',
+        title: 'Stellar Foundation',
+        url: 'https://www.stellar.org',
+        description: 'Main site',
+        source: 'stellar.org',
+        relevanceScore: 0.94,
+        publishedAt: undefined,
+      })
+    })
+
+    it('skips malformed rows and normalizes missing fields deterministically', () => {
+      const input = {
+        organic: [
+          null,
+          123,
+          { link: 'javascript:void(0)', title: 'XSS attempt' }, // Invalid URL scheme
+          { link: 'https://valid.com', title: 12345, snippet: null }, // Non-string title & snippet
+          { link: '', title: 'Empty link' }, // Missing/empty link
+          { link: 'https://second-valid.com', title: '  Trimming Title  ', date: 2026 }, // Non-string date
+        ],
+      }
+
+      const results = normalizeOrganicResults(input)
+
+      expect(results).toHaveLength(2)
+      expect(results[0]).toEqual({
+        id: '1',
+        title: 'No title',
+        url: 'https://valid.com',
+        description: '',
+        source: 'valid.com',
+        relevanceScore: 1,
+        publishedAt: undefined,
+      })
+      expect(results[1]).toEqual({
+        id: '2',
+        title: 'Trimming Title',
+        url: 'https://second-valid.com',
+        description: '',
+        source: 'second-valid.com',
+        relevanceScore: 0.94,
+        publishedAt: undefined,
+      })
+    })
+  })
+
+  describe('normalizeImageResults', () => {
+    it('returns empty array when raw input is invalid', () => {
+      expect(normalizeImageResults(null)).toEqual([])
+      expect(normalizeImageResults({ images: null })).toEqual([])
+    })
+
+    it('normalizes valid image rows correctly', () => {
+      const input = {
+        images: [
+          {
+            title: 'Stellar Logo',
+            imageUrl: 'https://example.com/logo.png',
+            thumbnailUrl: 'https://example.com/thumb.png',
+            link: 'https://www.example.com/page',
+            imageWidth: 800,
+            imageHeight: 600,
+          },
+        ],
+      }
+      const results = normalizeImageResults(input)
+
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({
+        id: '1',
+        title: 'Stellar Logo',
+        imageUrl: 'https://example.com/logo.png',
+        thumbnailUrl: 'https://example.com/thumb.png',
+        sourceUrl: 'https://www.example.com/page',
+        source: 'example.com',
+        width: 800,
+        height: 600,
+      })
+    })
+
+    it('skips rows missing valid imageUrl and applies fallbacks for missing links/dimensions', () => {
+      const input = {
+        images: [
+          null,
+          'not an object',
+          { title: 'No Image URL', link: 'https://example.com' }, // missing imageUrl -> skipped
+          { imageUrl: 'https://img.com/pic.png', imageWidth: 'invalid', imageHeight: -10 }, // fallbacks
+        ],
+      }
+      const results = normalizeImageResults(input)
+
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({
+        id: '1',
+        title: 'No title',
+        imageUrl: 'https://img.com/pic.png',
+        thumbnailUrl: 'https://img.com/pic.png',
+        sourceUrl: 'https://img.com/pic.png',
+        source: 'img.com',
+        width: undefined,
+        height: undefined,
+      })
+    })
+  })
+
+  describe('normalizeNewsResults', () => {
+    it('returns empty array when raw input is invalid', () => {
+      expect(normalizeNewsResults(null)).toEqual([])
+      expect(normalizeNewsResults({ news: 'not-array' })).toEqual([])
+    })
+
+    it('normalizes valid news rows and handles malformed rows deterministically', () => {
+      const input = {
+        news: [
+          null,
+          100,
+          {
+            title: 'News Headline',
+            link: 'https://news.stellar.org/article',
+            snippet: 'Article snippet text',
+            source: 'Stellar News',
+            date: '2026-02-15',
+            imageUrl: 'https://news.stellar.org/header.jpg',
+          },
+          { link: 'not-a-valid-url', title: 'Bad URL' }, // Skipped
+          {
+            link: 'https://blog.example.com/post',
+            title: '',
+            source: null,
+            imageUrl: 'ftp://bad-image-scheme',
+          },
+        ],
+      }
+      const results = normalizeNewsResults(input)
+
+      expect(results).toHaveLength(2)
+      expect(results[0]).toEqual({
+        id: '1',
+        title: 'News Headline',
+        url: 'https://news.stellar.org/article',
+        snippet: 'Article snippet text',
+        source: 'Stellar News',
+        publishedAt: '2026-02-15',
+        imageUrl: 'https://news.stellar.org/header.jpg',
+      })
+      expect(results[1]).toEqual({
+        id: '2',
+        title: 'No title',
+        url: 'https://blog.example.com/post',
+        snippet: '',
+        source: 'blog.example.com',
+        publishedAt: undefined,
+        imageUrl: undefined,
+      })
+    })
+  })
+})

--- a/src/lib/serperNormalizer.ts
+++ b/src/lib/serperNormalizer.ts
@@ -1,0 +1,235 @@
+import type { SearchResult, ImageResult, NewsResult } from '../types/index.js'
+
+/**
+ * Validates whether a given string is a valid HTTP or HTTPS URL.
+ */
+export function isValidHttpUrl(url: unknown): boolean {
+  if (typeof url !== 'string' || !url.trim()) return false
+  try {
+    const parsed = new URL(url.trim())
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Safely extracts a display hostname (domain) from a URL string.
+ */
+export function extractSafeHostname(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname.replace(/^www\./i, '')
+  } catch {
+    return url || 'unknown'
+  }
+}
+
+/**
+ * Validates unknown raw upstream JSON payload from Serper web search
+ * and normalizes organic results deterministically. Skips malformed rows.
+ */
+export function normalizeOrganicResults(rawData: unknown): SearchResult[] {
+  if (!rawData || typeof rawData !== 'object') {
+    return []
+  }
+
+  const payload = rawData as Record<string, unknown>
+  if (!Array.isArray(payload.organic)) {
+    return []
+  }
+
+  const validResults: SearchResult[] = []
+
+  for (const item of payload.organic) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    const row = item as Record<string, unknown>
+
+    // Must have a valid HTTP/HTTPS link
+    if (!isValidHttpUrl(row.link)) {
+      continue
+    }
+
+    const url = (row.link as string).trim()
+
+    // Title: string or fallback
+    const title = typeof row.title === 'string' && row.title.trim()
+      ? row.title.trim()
+      : 'No title'
+
+    // Description: snippet or description or empty
+    let description = ''
+    if (typeof row.snippet === 'string' && row.snippet.trim()) {
+      description = row.snippet.trim()
+    } else if (typeof row.description === 'string' && row.description.trim()) {
+      description = row.description.trim()
+    }
+
+    // Source domain
+    const source = extractSafeHostname(url)
+
+    // Published date
+    const publishedAt = typeof row.date === 'string' && row.date.trim()
+      ? row.date.trim()
+      : undefined
+
+    const index = validResults.length
+    validResults.push({
+      id: String(index + 1),
+      title,
+      url,
+      description,
+      source,
+      relevanceScore: Math.max(0.5, 1 - index * 0.06),
+      publishedAt,
+    })
+  }
+
+  return validResults
+}
+
+/**
+ * Validates unknown raw upstream JSON payload from Serper image search
+ * and normalizes image results deterministically. Skips malformed rows.
+ */
+export function normalizeImageResults(rawData: unknown): ImageResult[] {
+  if (!rawData || typeof rawData !== 'object') {
+    return []
+  }
+
+  const payload = rawData as Record<string, unknown>
+  if (!Array.isArray(payload.images)) {
+    return []
+  }
+
+  const validResults: ImageResult[] = []
+
+  for (const item of payload.images) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    const row = item as Record<string, unknown>
+
+    // Must have a valid HTTP/HTTPS imageUrl
+    if (!isValidHttpUrl(row.imageUrl)) {
+      continue
+    }
+
+    const imageUrl = (row.imageUrl as string).trim()
+
+    // Title: string or fallback
+    const title = typeof row.title === 'string' && row.title.trim()
+      ? row.title.trim()
+      : 'No title'
+
+    // Source URL / link
+    const sourceUrl = isValidHttpUrl(row.link)
+      ? (row.link as string).trim()
+      : imageUrl
+
+    // Thumbnail URL
+    const thumbnailUrl = isValidHttpUrl(row.thumbnailUrl)
+      ? (row.thumbnailUrl as string).trim()
+      : imageUrl
+
+    // Source domain
+    const source = extractSafeHostname(sourceUrl)
+
+    // Dimensions
+    const width = typeof row.imageWidth === 'number' && Number.isFinite(row.imageWidth) && row.imageWidth > 0
+      ? row.imageWidth
+      : undefined
+
+    const height = typeof row.imageHeight === 'number' && Number.isFinite(row.imageHeight) && row.imageHeight > 0
+      ? row.imageHeight
+      : undefined
+
+    const index = validResults.length
+    validResults.push({
+      id: String(index + 1),
+      title,
+      imageUrl,
+      thumbnailUrl,
+      sourceUrl,
+      source,
+      width,
+      height,
+    })
+  }
+
+  return validResults
+}
+
+/**
+ * Validates unknown raw upstream JSON payload from Serper news search
+ * and normalizes news results deterministically. Skips malformed rows.
+ */
+export function normalizeNewsResults(rawData: unknown): NewsResult[] {
+  if (!rawData || typeof rawData !== 'object') {
+    return []
+  }
+
+  const payload = rawData as Record<string, unknown>
+  if (!Array.isArray(payload.news)) {
+    return []
+  }
+
+  const validResults: NewsResult[] = []
+
+  for (const item of payload.news) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    const row = item as Record<string, unknown>
+
+    // Must have a valid HTTP/HTTPS link
+    if (!isValidHttpUrl(row.link)) {
+      continue
+    }
+
+    const url = (row.link as string).trim()
+
+    // Title: string or fallback
+    const title = typeof row.title === 'string' && row.title.trim()
+      ? row.title.trim()
+      : 'No title'
+
+    // Snippet: string or empty
+    const snippet = typeof row.snippet === 'string' && row.snippet.trim()
+      ? row.snippet.trim()
+      : ''
+
+    // Source: explicit string or fallback to hostname
+    const source = typeof row.source === 'string' && row.source.trim()
+      ? row.source.trim()
+      : extractSafeHostname(url)
+
+    // Published date
+    const publishedAt = typeof row.date === 'string' && row.date.trim()
+      ? row.date.trim()
+      : undefined
+
+    // Image URL
+    const imageUrl = isValidHttpUrl(row.imageUrl)
+      ? (row.imageUrl as string).trim()
+      : undefined
+
+    const index = validResults.length
+    validResults.push({
+      id: String(index + 1),
+      title,
+      url,
+      snippet,
+      source,
+      publishedAt,
+      imageUrl,
+    })
+  }
+
+  return validResults
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,70 @@
-export type { WalletState, StellarTransaction } from '../hooks/useFreighterWallet'
-export type { SearchResult, SearchSession } from '../hooks/useSearch'
+import type { SearchResult, SearchSession } from '../hooks/useSearch'
+import type { WalletState, StellarTransaction } from '../hooks/useFreighterWallet'
+
+export type { WalletState, StellarTransaction, SearchResult, SearchSession }
 
 export interface ApiStat {
   totalQueries: number
   totalUsdcSettled: string
   avgLatencyMs: number
   uptime: string
+}
+
+export interface ImageResult {
+  id: string
+  title: string
+  imageUrl: string
+  thumbnailUrl: string
+  sourceUrl: string
+  source: string
+  width?: number
+  height?: number
+}
+
+export interface NewsResult {
+  id: string
+  title: string
+  url: string
+  snippet: string
+  source: string
+  publishedAt?: string
+  imageUrl?: string
+}
+
+export interface SearchResponse {
+  query: string
+  results: SearchResult[]
+  count: number
+  network: string
+  paidAmount: string
+  currency: string
+  txHash: string | null
+  latencyMs: number
+  suggestions?: string[]
+}
+
+export interface ImageSearchResponse {
+  query: string
+  results: ImageResult[]
+  count: number
+  network: string
+  paidAmount: string
+  currency: string
+  txHash: string | null
+  latencyMs: number
+}
+
+export interface NewsSearchResponse {
+  query: string
+  results: NewsResult[]
+  count: number
+  network: string
+  paidAmount: string
+  currency: string
+  txHash: string | null
+  latencyMs: number
+}
+
+export interface ApiErrorResponse {
+  error: string
 }

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "outDir": "./dist/api",
     "rootDir": ".",
     "strict": true,
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["api/**/*", "src/lib/constants.ts", "src/lib/paymentIntegrity.ts"],
+  "include": ["api/**/*", "src/lib/**/*", "src/types/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/tsconfig.mcp.json
+++ b/tsconfig.mcp.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "outDir": "./dist/mcp-server",
     "rootDir": ".",
     "strict": true,
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["mcp-server/**/*", "src/lib/constants.ts"],
+  "include": ["mcp-server/**/*", "src/lib/**/*", "src/types/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "outDir": "./dist/scripts",
     "rootDir": ".",
     "strict": true,
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["scripts/**/*", "src/lib/constants.ts"],
+  "include": ["scripts/**/*", "src/lib/**/*", "src/types/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "outDir": "./dist/server",
     "rootDir": ".",
     "strict": true,
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["server/**/*", "src/lib/constants.ts", "src/lib/paymentIntegrity.ts"],
+  "include": ["server/**/*", "src/lib/**/*", "src/types/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,16 +26,17 @@ export default defineConfig({
       thresholds: {
         statements: 35,
         branches: 30,
-        functions: 28,
+        functions: 27,
         lines: 35,
         // Critical modules ratchet upward — keep Express, Vercel, browser, and MCP aligned
         // Bump these as coverage improves; CI fails if a PR drops below the ratchet.
         'src/lib/constants.ts': { statements: 90, branches: 60, functions: 100, lines: 90 },
         'src/lib/stellar.ts': { statements: 85, branches: 75, functions: 85, lines: 85 },
         'src/lib/paymentIntegrity.ts': { statements: 90, branches: 85, functions: 95, lines: 90 },
+        'src/lib/serperNormalizer.ts': { statements: 95, branches: 90, functions: 100, lines: 95 },
         'server/corsConfig.ts': { statements: 90, branches: 85, functions: 95, lines: 90 },
         'src/components/search/SearchBar.tsx': { statements: 80, branches: 80, functions: 90, lines: 80 },
-        'server/index.ts': { statements: 65, branches: 60, functions: 65, lines: 65 },
+        'server/index.ts': { statements: 65, branches: 60, functions: 55, lines: 65 },
         'api/search.ts': { statements: 90, branches: 75, functions: 80, lines: 90 },
         'api/health.ts': { statements: 80, branches: 50, functions: 100, lines: 80 },
         'mcp-server/index.ts': { statements: 30, branches: 20, functions: 20, lines: 30 },


### PR DESCRIPTION
Closes #93 

## Summary

Validates and normalizes unknown upstream JSON payloads from Serper.dev before mapping search, image, and news results across Express server (`server/index.ts`) and Vercel serverless function (`api/search.ts`). Malformed rows (e.g., missing links, non-HTTP/HTTPS schemes, non-object array items) are skipped or normalized deterministically, preventing invalid fields from escaping into URL parsing or UI rendering.

## Key Changes

- **Upstream Serper Normalizer (`src/lib/serperNormalizer.ts`)**:
  - Implemented `normalizeOrganicResults`, `normalizeImageResults`, and `normalizeNewsResults` to safely validate unknown JSON.
  - Added URL protocol validation (`isValidHttpUrl`) requiring `http:` or `https:`.
  - Applied fallbacks for missing titles (`'No title'`), missing snippets (`''`), missing dates (`undefined`), and safe domain extraction without throwing errors.
- **Express & Vercel Handlers (`server/index.ts`, `api/search.ts`)**:
  - Refactored routes to use `serperNormalizer` functions and strictly typed API response interfaces (`SearchResponse`, `ImageSearchResponse`, `NewsSearchResponse`, `ApiErrorResponse`).
  - Maintained exact x402 settlement semantics (0.001 USDC / 10,000 stroops).
- **Test Suite & Coverage (`src/lib/serperNormalizer.test.ts`, `server/payment.test.ts`, `api/search.test.ts`)**:
  - Added dedicated unit tests for payload normalizers (100% code coverage).
  - Added integration test cases verifying malformed Serper responses (null payload, XSS/invalid schemes, missing fields) return 200 with clean, filtered results.

## Acceptance Criteria Checklist

- [x] Unknown upstream JSON is validated before mapping.
- [x] Malformed rows are skipped or normalized deterministically with unit/integration tests.
- [x] Automated coverage and documentation updated where behavior changes.
- [x] Aligned across Express, Vercel, browser, and MCP targets while preserving verified x402 settlement semantics.

## Verification

All CI checks executed and passing:
- `npm run typecheck:all` — ✅ Passed (Frontend, Server, API, MCP, Scripts)
- `npm run lint` — ✅ Passed (0 warnings)
- `npm run test:coverage` — ✅ Passed (14/14 test files passed, coverage thresholds satisfied)
