### PR TITLE
feat: allow retrying a failed assistant turn without duplicating user messages

### DIFF
--- a/src/components/ai/GroqAssistant.test.tsx
+++ b/src/components/ai/GroqAssistant.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GroqAssistant } from './GroqAssistant'
+
+// Mock framer-motion to avoid animation issues in tests
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}))
+
+describe('GroqAssistant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = vi.fn()
+  })
+
+  it('renders floating button initially', () => {
+    render(<GroqAssistant />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('opens chat panel when clicked and allows retry on failure', async () => {
+    render(<GroqAssistant />)
+    
+    // Open chat
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    // Wait for the panel to open
+    expect(screen.getByPlaceholderText('Ask anything...')).toBeInTheDocument()
+
+    // Send a message
+    const input = screen.getByPlaceholderText('Ask anything...')
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    
+    // Mock a failed fetch
+    ;(global.fetch as any).mockRejectedValueOnce(new Error('Network error'))
+    
+    const sendButton = screen.getAllByRole('button').find(b => b.querySelector('svg.text-neon-cyan'))
+    fireEvent.click(sendButton!)
+
+    // Wait for error message
+    await waitFor(() => {
+      expect(screen.getByText(/Could not reach AI server/)).toBeInTheDocument()
+    })
+
+    // Verify Retry button appears
+    const retryButton = screen.getByText('Retry')
+    expect(retryButton).toBeInTheDocument()
+
+    // Mock successful fetch for retry
+    ;(global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ content: 'Hello! How can I help?', model: 'llama-3.1-8b-instant' })
+    })
+
+    // Click retry
+    fireEvent.click(retryButton)
+
+    // Ensure the network request is made again
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+    
+    // Check successful response replaced the error
+    await waitFor(() => {
+      expect(screen.queryByText(/Could not reach AI server/)).not.toBeInTheDocument()
+      expect(screen.getByText('Hello! How can I help?')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ai/GroqAssistant.tsx
+++ b/src/components/ai/GroqAssistant.tsx
@@ -7,6 +7,7 @@ interface Message {
   role: 'system' | 'user' | 'assistant'
   content: string
   model?: string // Add model info to messages
+  isError?: boolean // Flag to identify network/provider failures
 }
 
 interface LastSearch {
@@ -131,20 +132,28 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
     setMessages(prev => [...prev, buildSearchContextMessage(lastSearch)])
   }, [open, lastSearch])
 
-  const send = async () => {
-    if (!input.trim() || loading) return
-    const userMsg: Message = { role: 'user', content: input.trim() }
-    const history = [...messages, userMsg]
-    setMessages(history)
-    setInput('')
+  const send = async (retryHistory?: Message[], retryModel?: ModelId) => {
+    if ((!input.trim() && !retryHistory) || loading) return
+    
+    let history: Message[]
+    if (retryHistory) {
+      history = retryHistory
+    } else {
+      const userMsg: Message = { role: 'user', content: input.trim() }
+      history = [...messages, userMsg]
+      setMessages(history)
+      setInput('')
+    }
+    
     setLoading(true)
+    const currentModel = retryModel || selectedModel
 
     // Insert a placeholder assistant message we'll stream tokens into.
-    setMessages(prev => [...prev, { role: 'assistant', content: '', model: selectedModel }])
+    setMessages([...history, { role: 'assistant', content: '', model: currentModel }])
 
     const payload = JSON.stringify({
       messages: history.map(m => ({ role: m.role, content: m.content })),
-      model: selectedModel,
+      model: currentModel,
     })
 
     try {
@@ -167,7 +176,7 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
               const next = [...prev]
               const last = next[next.length - 1]
               if (last?.role === 'assistant') {
-                next[next.length - 1] = { ...last, content: last.content + delta }
+                next[next.length - 1] = { ...last, content: last.content + delta, isError: false }
               }
               return next
             })
@@ -192,7 +201,8 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
           next[next.length - 1] = { 
             role: 'assistant', 
             content: data.content ?? 'No response.',
-            model: data.model || selectedModel
+            model: data.model || currentModel,
+            isError: false
           }
           return next
         })
@@ -203,7 +213,8 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
         next[next.length - 1] = {
           role: 'assistant',
           content: `⚠️ Could not reach AI server: ${err.message}. Make sure the backend is running with GROQ_API_KEY set.`,
-          model: selectedModel,
+          model: currentModel,
+          isError: true
         }
         return next
       })
@@ -319,7 +330,9 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
 
             {/* Messages */}
             <div className="flex-1 overflow-y-auto p-3 space-y-3">
-              {messages.filter(m => m.role !== 'system').map((msg, i) => (
+              {messages.map((msg, i) => {
+                if (msg.role === 'system') return null;
+                return (
                 <motion.div
                   key={i}
                   initial={{ opacity: 0, y: 8 }}
@@ -331,23 +344,48 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
                     style={{
                       background: msg.role === 'user'
                         ? 'rgba(0,245,255,0.15)'
+                        : msg.isError
+                        ? 'rgba(255,0,0,0.15)'
                         : 'rgba(255,255,255,0.05)',
                       border: msg.role === 'user'
                         ? '1px solid rgba(0,245,255,0.3)'
+                        : msg.isError
+                        ? '1px solid rgba(255,0,0,0.3)'
                         : '1px solid rgba(255,255,255,0.07)',
-                      color: msg.role === 'user' ? '#00f5ff' : 'rgba(255,255,255,0.7)',
+                      color: msg.role === 'user'
+                        ? '#00f5ff'
+                        : msg.isError
+                        ? '#ff4444'
+                        : 'rgba(255,255,255,0.7)',
                     }}
                   >
                     {msg.content}
                   </div>
                   {/* Show model metadata for assistant messages */}
-                  {msg.role === 'assistant' && msg.model && (
-                    <div className="text-[10px] text-white/30 mt-1 px-1">
-                      {getModelLabel(msg.model)}
+                  {msg.role === 'assistant' && (
+                    <div className="flex items-center gap-2 mt-1 px-1">
+                      {msg.model && (
+                        <div className="text-[10px] text-white/30">
+                          {getModelLabel(msg.model)}
+                        </div>
+                      )}
+                      {msg.isError && !loading && (
+                        <button
+                          onClick={() => send(messages.slice(0, i), msg.model as ModelId)}
+                          className="text-[10px] text-neon-cyan hover:text-neon-cyan/80 transition-colors flex items-center gap-1"
+                        >
+                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                            <path d="M3 3v5h5" />
+                          </svg>
+                          Retry
+                        </button>
+                      )}
                     </div>
                   )}
                 </motion.div>
-              ))}
+                )
+              })}
 
               {loading && (
                 <div className="flex justify-start">


### PR DESCRIPTION
Closes #164

Fixes an issue where network or provider failures in the AI assistant resulted in permanent, unretryable error bubbles. 

### Changes made
* Added an `isError` flag to the `Message` interface to detect failed assistant turns.
* Modified the `send` method in `GroqAssistant.tsx` to accept a `retryHistory` array. 
* Updated the message renderer to display a **Retry** button for failed messages. 
* Clicking **Retry** now isolates and resends the exact prior conversation history (using the same selected model), preventing duplicate user submissions and updating the placeholder.
* Maintained existing Express server boundary semantics and added unit test coverage in `src/components/ai/GroqAssistant.test.tsx` to validate the retry logic.