### PR TITLE
Map Serper auth, quota, rate-limit, and outage errors separately (#119)

### DIFF
--- a/api/search.test.ts
+++ b/api/search.test.ts
@@ -155,6 +155,33 @@ describe('api/search — Vercel x402 settlement (aligned with Express)', () => {
     })
     await handler(req, res)
     expect(res._status).toBe(502)
+    expect(res._json.providerCode).toBe('SERPER_PROVIDER_ERROR')
+  })
+
+  it('MCP/browser alignment: maps distinct Serper statuses to stable error codes', async () => {
+    const cases: Array<{ upstream: number; expectedStatus: number; expectedCode: string }> = [
+      { upstream: 401, expectedStatus: 503, expectedCode: 'SERPER_AUTH_FAILURE' },
+      { upstream: 403, expectedStatus: 503, expectedCode: 'SERPER_QUOTA_EXCEEDED' },
+      { upstream: 429, expectedStatus: 429, expectedCode: 'SERPER_RATE_LIMITED' },
+      { upstream: 502, expectedStatus: 502, expectedCode: 'SERPER_PROVIDER_ERROR' },
+    ]
+
+    for (const c of cases) {
+      const fakeTx = Buffer.from(JSON.stringify({ transactionHash: `tx_map_${c.upstream}` })).toString('base64')
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: c.upstream,
+        text: async () => 'upstream body',
+      } as any)
+      const { req, res } = mockReqRes({
+        method: 'GET',
+        query: { q: 'stellar' },
+        headers: { 'x-payment': fakeTx },
+      })
+      await handler(req, res)
+      expect(res._status).toBe(c.expectedStatus)
+      expect(res._json.providerCode).toBe(c.expectedCode)
+    }
   })
 
   it('applies freshness filter', async () => {

--- a/api/search.ts
+++ b/api/search.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/lib/constants'
 import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
 import { normalizeOrganicResults } from '../src/lib/serperNormalizer'
+import { mapSerperStatus, mapSerperNetworkError } from '../src/lib/serperError'
 import type { SearchResponse, ApiErrorResponse } from '../src/types/index.js'
 
 // ─── Config ───────────────────────────────────────────────────────────────
@@ -132,8 +133,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!serperRes.ok) {
       const errText = await serperRes.text()
       console.error('[serper]', serperRes.status, errText)
-      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
-      return res.status(502).json(errorBody)
+      const mapped = mapSerperStatus(serperRes.status)
+      return res.status(mapped.httpStatus).json(mapped.body)
     }
 
     const data: unknown = await serperRes.json()
@@ -156,7 +157,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   } catch (err: any) {
     console.error('[search error]', err.message)
-    const errorBody: ApiErrorResponse = { error: 'Search failed.' }
-    return res.status(500).json(errorBody)
+    const mapped = mapSerperNetworkError()
+    return res.status(mapped.httpStatus).json(mapped.body)
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -41,6 +41,7 @@ import type {
   NewsSearchResponse,
   ApiErrorResponse,
 } from '../src/types/index.js'
+import { mapSerperStatus, mapSerperNetworkError } from '../src/lib/serperError.js'
 
 dotenv.config()
 
@@ -251,10 +252,10 @@ app.get('/search', async (req: Request, res: Response) => {
     })
 
     if (!serperRes.ok) {
-      const err = await serperRes.text()
-      console.error('[serper]', serperRes.status, err)
-      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
-      return res.status(502).json(errorBody)
+      const errText = await serperRes.text()
+      console.error('[serper]', serperRes.status, errText)
+      const mapped = mapSerperStatus(serperRes.status)
+      return res.status(mapped.httpStatus).json(mapped.body)
     }
 
     const data: unknown = await serperRes.json()
@@ -321,8 +322,8 @@ app.get('/search', async (req: Request, res: Response) => {
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[search error]', err.message)
-    const errorBody: ApiErrorResponse = { error: 'Search failed. Check server logs.' }
-    return res.status(500).json(errorBody)
+    const mapped = mapSerperNetworkError()
+    return res.status(mapped.httpStatus).json(mapped.body)
   }
 })
 
@@ -353,10 +354,10 @@ app.get('/images', async (req: Request, res: Response) => {
     })
 
     if (!serperRes.ok) {
-      const err = await serperRes.text()
-      console.error('[serper images]', serperRes.status, err)
-      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
-      return res.status(502).json(errorBody)
+      const errText = await serperRes.text()
+      console.error('[serper images]', serperRes.status, errText)
+      const mapped = mapSerperStatus(serperRes.status)
+      return res.status(mapped.httpStatus).json(mapped.body)
     }
 
     const data: unknown = await serperRes.json()
@@ -385,8 +386,8 @@ app.get('/images', async (req: Request, res: Response) => {
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[images error]', err.message)
-    const errorBody: ApiErrorResponse = { error: 'Image search failed. Check server logs.' }
-    return res.status(500).json(errorBody)
+    const mapped = mapSerperNetworkError()
+    return res.status(mapped.httpStatus).json(mapped.body)
   }
 })
 
@@ -430,10 +431,10 @@ app.get('/news', async (req: Request, res: Response) => {
     })
 
     if (!serperRes.ok) {
-      const err = await serperRes.text()
-      console.error('[serper news]', serperRes.status, err)
-      const errorBody: ApiErrorResponse = { error: `Serper.dev API error: ${serperRes.status}` }
-      return res.status(502).json(errorBody)
+      const errText = await serperRes.text()
+      console.error('[serper news]', serperRes.status, errText)
+      const mapped = mapSerperStatus(serperRes.status)
+      return res.status(mapped.httpStatus).json(mapped.body)
     }
 
     const data: unknown = await serperRes.json()
@@ -462,8 +463,8 @@ app.get('/news', async (req: Request, res: Response) => {
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[news error]', err.message)
-    const errorBody: ApiErrorResponse = { error: 'News search failed. Check server logs.' }
-    return res.status(500).json(errorBody)
+    const mapped = mapSerperNetworkError()
+    return res.status(mapped.httpStatus).json(mapped.body)
   }
 })
 

--- a/server/payment.test.ts
+++ b/server/payment.test.ts
@@ -195,29 +195,39 @@ describe('settle — successful search after payment', () => {
 // ─── Reject ───────────────────────────────────────────────────────────────────
 
 describe('reject — upstream errors after payment header is present', () => {
-  it('returns 502 when Serper responds 500', async () => {
+  it('returns 502 when Serper responds 500 (provider error)', async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => 'internal error' } as any)
     const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_500'))
     expect(res.status).toBe(502)
-    expect(res.body.error).toMatch(/Serper/)
+    expect(res.body.providerCode).toBe('SERPER_PROVIDER_ERROR')
   })
 
-  it('returns 502 when Serper responds 403 (bad API key)', async () => {
+  it('returns 503 when Serper responds 403 (quota exceeded)', async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403, text: async () => 'forbidden' } as any)
     const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_403'))
-    expect(res.status).toBe(502)
+    expect(res.status).toBe(503)
+    expect(res.body.providerCode).toBe('SERPER_QUOTA_EXCEEDED')
   })
 
-  it('returns 502 when /images Serper responds with error', async () => {
+  it('returns 429 when /images Serper responds with rate limit', async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429, text: async () => 'rate limited' } as any)
     const res = await request(app).get('/images?q=stellar').set('x-payment', makeReceipt('tx_rej_img'))
-    expect(res.status).toBe(502)
+    expect(res.status).toBe(429)
+    expect(res.body.providerCode).toBe('SERPER_RATE_LIMITED')
   })
 
-  it('returns 500 when fetch throws (network failure)', async () => {
+  it('returns 502 when fetch throws (network failure)', async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
     const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_net'))
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(502)
+    expect(res.body.providerCode).toBe('SERPER_NETWORK_ERROR')
+  })
+
+  it('returns 503 when Serper responds 401 (auth failure)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401, text: async () => 'unauthorized' } as any)
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_rej_401'))
+    expect(res.status).toBe(503)
+    expect(res.body.providerCode).toBe('SERPER_AUTH_FAILURE')
   })
 })
 

--- a/src/lib/serperError.test.ts
+++ b/src/lib/serperError.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { mapSerperStatus, mapSerperNetworkError } from './serperError'
+import { SerperErrorCode } from '../types/index'
+
+describe('mapSerperStatus', () => {
+  it('maps 401 to AUTH_FAILURE with 503', () => {
+    const result = mapSerperStatus(401)
+    expect(result.httpStatus).toBe(503)
+    expect(result.body.providerCode).toBe(SerperErrorCode.AUTH_FAILURE)
+    expect(result.body.error).toContain('invalid or missing')
+  })
+
+  it('maps 403 to QUOTA_EXCEEDED with 503', () => {
+    const result = mapSerperStatus(403)
+    expect(result.httpStatus).toBe(503)
+    expect(result.body.providerCode).toBe(SerperErrorCode.QUOTA_EXCEEDED)
+    expect(result.body.error).toContain('quota')
+  })
+
+  it('maps 429 to RATE_LIMITED with 429', () => {
+    const result = mapSerperStatus(429)
+    expect(result.httpStatus).toBe(429)
+    expect(result.body.providerCode).toBe(SerperErrorCode.RATE_LIMITED)
+    expect(result.body.error).toContain('rate limit')
+  })
+
+  it('maps 500 to PROVIDER_ERROR with 502', () => {
+    const result = mapSerperStatus(500)
+    expect(result.httpStatus).toBe(502)
+    expect(result.body.providerCode).toBe(SerperErrorCode.PROVIDER_ERROR)
+    expect(result.body.error).toContain('server error')
+  })
+
+  it('maps 502 to PROVIDER_ERROR with 502', () => {
+    const result = mapSerperStatus(502)
+    expect(result.httpStatus).toBe(502)
+    expect(result.body.providerCode).toBe(SerperErrorCode.PROVIDER_ERROR)
+  })
+
+  it('maps 503 to PROVIDER_ERROR with 502', () => {
+    const result = mapSerperStatus(503)
+    expect(result.httpStatus).toBe(502)
+    expect(result.body.providerCode).toBe(SerperErrorCode.PROVIDER_ERROR)
+  })
+
+  it('maps unknown 4xx to PROVIDER_ERROR with 502', () => {
+    const result = mapSerperStatus(418)
+    expect(result.httpStatus).toBe(502)
+    expect(result.body.providerCode).toBe(SerperErrorCode.PROVIDER_ERROR)
+  })
+
+  it('always includes providerCode in body', () => {
+    for (const status of [401, 403, 429, 500, 502, 503, 418]) {
+      const result = mapSerperStatus(status)
+      expect(result.body.providerCode).toBeDefined()
+      expect(Object.values(SerperErrorCode)).toContain(result.body.providerCode)
+    }
+  })
+})
+
+describe('mapSerperNetworkError', () => {
+  it('returns 502 with NETWORK_ERROR code', () => {
+    const result = mapSerperNetworkError()
+    expect(result.httpStatus).toBe(502)
+    expect(result.body.providerCode).toBe(SerperErrorCode.NETWORK_ERROR)
+    expect(result.body.error).toContain('Unable to reach')
+  })
+})
+
+describe('error code stability', () => {
+  it('all error codes are unique strings', () => {
+    const codes = Object.values(SerperErrorCode)
+    const unique = new Set(codes)
+    expect(unique.size).toBe(codes.length)
+  })
+
+  it('every mapped status produces a stable, client-safe error code', () => {
+    const statuses = [401, 403, 429, 500, 502, 503, 418]
+    const clientCodes = statuses.map((s) => mapSerperStatus(s).body.providerCode)
+    for (const code of clientCodes) {
+      expect(code).toMatch(/^SERPER_/)
+    }
+  })
+})

--- a/src/lib/serperError.ts
+++ b/src/lib/serperError.ts
@@ -1,0 +1,56 @@
+import { SerperErrorCode, type ApiErrorResponse } from '../types/index.js'
+
+export interface SerperErrorResult {
+  httpStatus: number
+  body: ApiErrorResponse
+}
+
+const ERROR_LABELS: Record<SerperErrorCode, string> = {
+  [SerperErrorCode.AUTH_FAILURE]:   'Serper API key is invalid or missing',
+  [SerperErrorCode.QUOTA_EXCEEDED]: 'Serper API quota has been exceeded',
+  [SerperErrorCode.RATE_LIMITED]:   'Serper rate limit exceeded',
+  [SerperErrorCode.PROVIDER_ERROR]: 'Serper returned a server error',
+  [SerperErrorCode.NETWORK_ERROR]:  'Unable to reach Serper API',
+}
+
+export function mapSerperStatus(status: number): SerperErrorResult {
+  let code: SerperErrorCode
+  let httpStatus: number
+
+  switch (status) {
+    case 401:
+      code = SerperErrorCode.AUTH_FAILURE
+      httpStatus = 503
+      break
+    case 403:
+      code = SerperErrorCode.QUOTA_EXCEEDED
+      httpStatus = 503
+      break
+    case 429:
+      code = SerperErrorCode.RATE_LIMITED
+      httpStatus = 429
+      break
+    default:
+      code = SerperErrorCode.PROVIDER_ERROR
+      httpStatus = 502
+      break
+  }
+
+  return {
+    httpStatus,
+    body: {
+      error:       ERROR_LABELS[code],
+      providerCode: code,
+    },
+  }
+}
+
+export function mapSerperNetworkError(): SerperErrorResult {
+  return {
+    httpStatus: 502,
+    body: {
+      error:       ERROR_LABELS[SerperErrorCode.NETWORK_ERROR],
+      providerCode: SerperErrorCode.NETWORK_ERROR,
+    },
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -114,8 +114,17 @@ export interface NewsSearchResponse {
   latencyMs: number
 }
 
+export enum SerperErrorCode {
+  AUTH_FAILURE    = 'SERPER_AUTH_FAILURE',
+  QUOTA_EXCEEDED  = 'SERPER_QUOTA_EXCEEDED',
+  RATE_LIMITED    = 'SERPER_RATE_LIMITED',
+  PROVIDER_ERROR  = 'SERPER_PROVIDER_ERROR',
+  NETWORK_ERROR   = 'SERPER_NETWORK_ERROR',
+}
+
 export interface ApiErrorResponse {
   error: string
+  providerCode?: SerperErrorCode
 }
 
 // Aliases for response types

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         'src/lib/stellar.ts': { statements: 85, branches: 75, functions: 85, lines: 85 },
         'src/lib/paymentIntegrity.ts': { statements: 90, branches: 85, functions: 95, lines: 90 },
         'src/lib/serperNormalizer.ts': { statements: 95, branches: 90, functions: 100, lines: 95 },
+        'src/lib/serperError.ts': { statements: 100, branches: 100, functions: 100, lines: 100 },
         'server/corsConfig.ts': { statements: 90, branches: 85, functions: 95, lines: 90 },
         'src/components/search/SearchBar.tsx': { statements: 80, branches: 80, functions: 90, lines: 80 },
         'server/index.ts': { statements: 65, branches: 60, functions: 55, lines: 65 },


### PR DESCRIPTION
Closes #119

## Summary

All non-OK Serper.dev provider responses previously collapsed into a single generic 502 (`Serper.dev API error: <status>`), giving operators and clients little actionable signal about whether an outage, a dead API key, a quota, or rate limiting was the cause.

This PR maps provider statuses to **stable internal error codes** exposed to clients via a new `providerCode` field, alongside a safe, human-readable message. Sensitive upstream response bodies remain **server-side only** (console/log), never forwarded to clients.

## Error mapping

| Upstream | Internal code | HTTP response |
|----------|---------------|---------------|
| 401 | `SERPER_AUTH_FAILURE` | 503 |
| 403 | `SERPER_QUOTA_EXCEEDED` | 503 |
| 429 | `SERPER_RATE_LIMITED` | 429 |
| 5xx / unknown | `SERPER_PROVIDER_ERROR` | 502 |
| network failure | `SERPER_NETWORK_ERROR` | 502 |

## Changes

- Added `SerperErrorCode` enum and extended `ApiErrorResponse` with an optional `providerCode` in `src/types/index.ts`.
- Added a centralized, dependency-free mapping module `src/lib/serperError.ts` (`mapSerperStatus`, `mapSerperNetworkError`).
- Wired the mapping into all four provider call sites:
  - `server/index.ts` — `/search`, `/images`, `/news` (Express)
  - `api/search.ts` — Vercel serverless handler
- Extended `ApiErrorResponse` cross-runtime (Express, Vercel, browser, MCP) so the same `providerCode` is consistently available.
- Placed the module under `src/lib/` rather than `server/` so it can be imported by both the Vercel serverless function and the Express server without pulling in server-only (winston) deps.
- Added unit tests + updated existing Express/Vercel error tests to assert stable codes; added a coverage ratchet for the new module (100%).

## x402 settlement preserved

Payment/replay semantics are untouched — this only changes how **non-OK Serper responses** after payment are formatted. All existing x402 settlement, replay, and concurrency tests still pass (212 tests).

## Verification

- `npm run typecheck:all` — clean
- `npm run lint` — clean
- `vitest run` — 212 passed
- New module coverage — 100% statements/branches/functions/lines

## For operators

The request-scoped detail (upstream status + body) stays in server logs; clients get the stable `providerCode` so they can branch on authentication/quota/rate-limit/outage without ever seeing raw upstream content.