### PR TITLE
fix(a11y): pause live ticker and hide duplicated content from screen readers

### DIFF
--- a/src/components/layout/LiveTicker.test.tsx
+++ b/src/components/layout/LiveTicker.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LiveTicker } from './LiveTicker'
+
+describe('LiveTicker — accessibility', () => {
+  it('exposes exactly one semantic copy of each item to assistive tech', () => {
+    render(<LiveTicker walletConnected={false} />)
+    expect(screen.getAllByText('PROTOCOL')).toHaveLength(1)
+    expect(screen.getAllByText('x402')).toHaveLength(1)
+  })
+
+  it('hides the duplicated loop copy from screen readers', () => {
+    const { container } = render(<LiveTicker walletConnected={false} />)
+    const hidden = container.querySelector('[aria-hidden="true"]')
+    expect(hidden).not.toBeNull()
+    expect(hidden?.textContent).toContain('PROTOCOL')
+  })
+
+  it('exposes the ticker as a focusable marquee region', () => {
+    render(<LiveTicker walletConnected={true} />)
+    const marquee = screen.getByRole('marquee')
+    expect(marquee).toHaveAttribute('tabindex', '0')
+  })
+
+  it('reflects wallet connection status', () => {
+    render(<LiveTicker walletConnected={true} />)
+    expect(screen.getAllByText('WALLET CONNECTED')).toHaveLength(1)
+  })
+})

--- a/src/components/layout/LiveTicker.tsx
+++ b/src/components/layout/LiveTicker.tsx
@@ -14,14 +14,31 @@ const getTickerItems = () => [
   ['WALLET',     'FREIGHTER'],
 ]
 
+function TickerItem({ item: [k, v] }: { item: string[] }) {
+  return (
+    <div className="inline-flex items-center gap-2 px-6">
+      <span
+        className="font-display text-neon-cyan/30 tracking-widest"
+        style={{ fontSize: '10px' }}
+      >
+        {k}
+      </span>
+      <span
+        className="font-display text-neon-cyan font-bold tracking-wider"
+        style={{ fontSize: '10px' }}
+      >
+        {v}
+      </span>
+      <span className="text-neon-cyan/15">◆</span>
+    </div>
+  )
+}
+
 export function LiveTicker({ walletConnected }: Props) {
   const items = [
     ...getTickerItems(),
     ['STATUS', walletConnected ? 'WALLET CONNECTED' : 'NOT CONNECTED'],
   ]
-
-  // Duplicate for seamless loop
-  const doubled = [...items, ...items]
 
   return (
     <div
@@ -31,24 +48,19 @@ export function LiveTicker({ walletConnected }: Props) {
       <div
         className="flex items-center gap-8 animate-ticker whitespace-nowrap"
         style={{ width: 'max-content' }}
+        tabIndex={0}
+        role="marquee"
+        aria-label="Live network status"
       >
-        {doubled.map(([k, v], i) => (
-          <div key={i} className="inline-flex items-center gap-2 px-6">
-            <span
-              className="font-display text-neon-cyan/30 tracking-widest"
-              style={{ fontSize: '10px' }}
-            >
-              {k}
-            </span>
-            <span
-              className="font-display text-neon-cyan font-bold tracking-wider"
-              style={{ fontSize: '10px' }}
-            >
-              {v}
-            </span>
-            <span className="text-neon-cyan/15">◆</span>
-          </div>
+        {items.map((item, i) => (
+          <TickerItem key={i} item={item} />
         ))}
+        {/* Duplicated for the seamless scroll loop only; hidden so screen readers see one copy. */}
+        <div aria-hidden="true" className="flex items-center gap-8">
+          {items.map((item, i) => (
+            <TickerItem key={i} item={item} />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,13 @@
   100% { transform: translateX(-50%); }
 }
 .animate-ticker { animation: ticker 30s linear infinite; }
+.animate-ticker:hover,
+.animate-ticker:focus,
+.animate-ticker:focus-within { animation-play-state: paused; }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-ticker { animation: none; }
+}
 
 @keyframes scan {
   0% { top: 0%; }


### PR DESCRIPTION
## What does this PR do?
Makes the LiveTicker's scrolling marquee pause on hover, keyboard focus, and under `prefers-reduced-motion`, and exposes only one semantic copy of its content to assistive technology instead of the duplicated loop copy.

## Which issue does it close?
Closes #148

## How was it tested?
Added unit tests in `src/components/layout/LiveTicker.test.tsx` covering that only one copy of each ticker item is exposed to assistive tech, that the duplicated loop copy carries `aria-hidden="true"`, and that the ticker region is a focusable `marquee` landmark.

## Screenshots
No visual changes; the ticker's appearance and scroll animation are unchanged. Only its pause behavior and accessibility tree output differ.