### PR TITLE
fix: render AI markdown safely and link summary citations to result cards (#166)

### DIFF
--- a/src/components/ai/AiMarkdown.test.tsx
+++ b/src/components/ai/AiMarkdown.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AiMarkdown } from './AiMarkdown'
+
+describe('AiMarkdown', () => {
+  it('renders bold, italic, and inline code without leaking raw markup', () => {
+    render(<AiMarkdown content="**bold** and *italic* and `code`" />)
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getByText('italic').tagName).toBe('EM')
+    expect(screen.getByText('code').tagName).toBe('CODE')
+  })
+
+  it('never injects raw HTML — tags in source are shown as literal text', () => {
+    render(<AiMarkdown content='<img src=x onerror="window.__pwned=true">' />)
+    expect((window as any).__pwned).toBeUndefined()
+    expect(document.querySelector('img')).toBeNull()
+    expect(screen.getByText(/<img/)).toBeInTheDocument()
+  })
+
+  it('renders lists and headings', () => {
+    render(<AiMarkdown content={'## Heading\n- one\n- two'} />)
+    expect(screen.getByText('Heading')).toBeInTheDocument()
+    expect(screen.getByText('one').closest('li')).toBeInTheDocument()
+    expect(screen.getByText('two').closest('li')).toBeInTheDocument()
+  })
+
+  it('renders a safe http(s) link', () => {
+    render(<AiMarkdown content="[Stellar](https://stellar.org)" />)
+    const link = screen.getByText('Stellar')
+    expect(link.tagName).toBe('A')
+    expect(link.getAttribute('href')).toBe('https://stellar.org')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('turns a valid numbered citation into a clickable control', () => {
+    const onCitationClick = vi.fn()
+    render(<AiMarkdown content="See [1] for details." citationMax={3} onCitationClick={onCitationClick} />)
+    const btn = screen.getByRole('button', { name: /jump to source 1/i })
+    fireEvent.click(btn)
+    expect(onCitationClick).toHaveBeenCalledWith(1)
+  })
+
+  it('leaves an out-of-range citation as plain text', () => {
+    render(<AiMarkdown content="See [9] for details." citationMax={3} />)
+    expect(screen.queryByRole('button', { name: /jump to source 9/i })).toBeNull()
+    expect(screen.getByText(/\[9\]/)).toBeInTheDocument()
+  })
+
+  it('falls back to focusing the matching result card when no handler is given', () => {
+    const card = document.createElement('div')
+    card.id = 'result-card-2'
+    card.tabIndex = -1
+    document.body.appendChild(card)
+    const scrollSpy = vi.fn()
+    card.scrollIntoView = scrollSpy
+
+    render(<AiMarkdown content="Backed by [2]." citationMax={2} />)
+    fireEvent.click(screen.getByRole('button', { name: /jump to source 2/i }))
+
+    expect(scrollSpy).toHaveBeenCalled()
+    expect(document.activeElement).toBe(card)
+
+    document.body.removeChild(card)
+  })
+
+  it('renders nothing for empty content', () => {
+    const { container } = render(<AiMarkdown content="" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/ai/AiMarkdown.tsx
+++ b/src/components/ai/AiMarkdown.tsx
@@ -1,0 +1,203 @@
+import { Fragment, type ReactNode } from 'react'
+
+interface Props {
+  content: string
+  /** Highest citation number considered valid, e.g. the number of results shown. */
+  citationMax?: number
+  /** Called when a valid numbered citation (e.g. `[1]`) is activated. */
+  onCitationClick?: (index: number) => void
+}
+
+let inlineKey = 0
+let blockKey = 0
+
+const LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/
+const CITATION_RE = /\[(\d+)\]/
+const BOLD_RE = /\*\*([^*]+)\*\*/
+const CODE_RE = /`([^`]+)`/
+const ITALIC_RE = /(?<![*\w])\*([^*]+)\*(?!\w)/
+
+// Parses a single line of text into safe inline React nodes. No HTML is ever
+// injected — every fragment is a literal string or a controlled element, so
+// there is no path for raw markup to execute.
+function renderInline(text: string, citationMax: number | undefined, onCitationClick: Props['onCitationClick']): ReactNode[] {
+  if (!text) return []
+
+  const matchers: Array<{ re: RegExp; render: (m: RegExpMatchArray) => ReactNode }> = [
+    {
+      re: LINK_RE,
+      render: m => (
+        <a
+          key={`il-${inlineKey++}`}
+          href={m[2]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline decoration-dotted hover:text-neon-cyan"
+        >
+          {m[1]}
+        </a>
+      ),
+    },
+    {
+      re: CITATION_RE,
+      render: m => {
+        const n = parseInt(m[1], 10)
+        const isValid = n >= 1 && (citationMax === undefined || n <= citationMax)
+        if (!isValid) return m[0]
+        return (
+          <button
+            key={`il-${inlineKey++}`}
+            type="button"
+            onClick={e => {
+              e.preventDefault()
+              e.stopPropagation()
+              if (onCitationClick) {
+                onCitationClick(n)
+              } else if (typeof document !== 'undefined') {
+                const el = document.getElementById(`result-card-${n}`)
+                if (el) {
+                  el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                  ;(el as HTMLElement).focus({ preventScroll: true })
+                }
+              }
+            }}
+            className="inline-flex items-center px-1 rounded text-neon-cyan hover:underline align-baseline"
+            aria-label={`Jump to source ${n}`}
+          >
+            [{n}]
+          </button>
+        )
+      },
+    },
+    {
+      re: BOLD_RE,
+      render: m => <strong key={`il-${inlineKey++}`}>{renderInline(m[1], citationMax, onCitationClick)}</strong>,
+    },
+    {
+      re: CODE_RE,
+      render: m => (
+        <code key={`il-${inlineKey++}`} className="px-1 py-0.5 rounded bg-white/10 font-mono text-[0.9em]">
+          {m[1]}
+        </code>
+      ),
+    },
+    {
+      re: ITALIC_RE,
+      render: m => <em key={`il-${inlineKey++}`}>{renderInline(m[1], citationMax, onCitationClick)}</em>,
+    },
+  ]
+
+  let earliest: { index: number; match: RegExpMatchArray; render: (m: RegExpMatchArray) => ReactNode } | null = null
+  for (const { re, render } of matchers) {
+    const m = text.match(re)
+    if (m && m.index !== undefined && (earliest === null || m.index < earliest.index)) {
+      earliest = { index: m.index, match: m, render }
+    }
+  }
+
+  if (!earliest) return [text]
+
+  const before = text.slice(0, earliest.index)
+  const after = text.slice(earliest.index + earliest.match[0].length)
+  const nodes: ReactNode[] = []
+  if (before) nodes.push(before)
+  nodes.push(earliest.render(earliest.match))
+  nodes.push(...renderInline(after, citationMax, onCitationClick))
+  return nodes
+}
+
+// Renders a restricted, safe subset of Markdown (headings, bold/italic,
+// inline code, fenced code blocks, lists, links) as React elements. There is
+// no `dangerouslySetInnerHTML` anywhere in this component, so arbitrary HTML
+// in the source text is never parsed or executed — it is only ever treated
+// as literal text.
+export function AiMarkdown({ content, citationMax, onCitationClick }: Props) {
+  if (!content) return null
+
+  const lines = content.split('\n')
+  const blocks: ReactNode[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (line.trim().startsWith('```')) {
+      const codeLines: string[] = []
+      i++
+      while (i < lines.length && !lines[i].trim().startsWith('```')) {
+        codeLines.push(lines[i])
+        i++
+      }
+      i++ // consume closing fence
+      blocks.push(
+        <pre key={`bl-${blockKey++}`} className="rounded-lg bg-white/5 border border-white/10 p-2 overflow-x-auto text-[0.85em] font-mono whitespace-pre-wrap">
+          <code>{codeLines.join('\n')}</code>
+        </pre>
+      )
+      continue
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/)
+    if (headingMatch) {
+      const level = headingMatch[1].length
+      const sizes = ['text-base', 'text-base', 'text-sm', 'text-sm', 'text-xs', 'text-xs']
+      blocks.push(
+        <p key={`bl-${blockKey++}`} className={`font-semibold ${sizes[level - 1]}`}>
+          {renderInline(headingMatch[2], citationMax, onCitationClick)}
+        </p>
+      )
+      i++
+      continue
+    }
+
+    if (/^\s*[-*]\s+/.test(line)) {
+      const items: string[] = []
+      while (i < lines.length && /^\s*[-*]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*[-*]\s+/, ''))
+        i++
+      }
+      blocks.push(
+        <ul key={`bl-${blockKey++}`} className="list-disc pl-4 space-y-0.5">
+          {items.map((it, idx) => (
+            <li key={idx}>{renderInline(it, citationMax, onCitationClick)}</li>
+          ))}
+        </ul>
+      )
+      continue
+    }
+
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: string[] = []
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*\d+\.\s+/, ''))
+        i++
+      }
+      blocks.push(
+        <ol key={`bl-${blockKey++}`} className="list-decimal pl-4 space-y-0.5">
+          {items.map((it, idx) => (
+            <li key={idx}>{renderInline(it, citationMax, onCitationClick)}</li>
+          ))}
+        </ol>
+      )
+      continue
+    }
+
+    if (line.trim() === '') {
+      i++
+      continue
+    }
+
+    blocks.push(
+      <p key={`bl-${blockKey++}`}>{renderInline(line, citationMax, onCitationClick)}</p>
+    )
+    i++
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {blocks.map((b, idx) => (
+        <Fragment key={idx}>{b}</Fragment>
+      ))}
+    </div>
+  )
+}

--- a/src/components/ai/GroqAssistant.tsx
+++ b/src/components/ai/GroqAssistant.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Bot, Send, X, ChevronDown } from 'lucide-react'
 import type { SearchResult } from '../../hooks/useSearch'
+import { AiMarkdown } from './AiMarkdown'
 
 interface Message {
   role: 'system' | 'user' | 'assistant'
@@ -335,7 +336,14 @@ export function GroqAssistant({ lastSearch }: Props = {}) {
                       color: msg.role === 'user' ? '#00f5ff' : 'rgba(255,255,255,0.7)',
                     }}
                   >
-                    {msg.content}
+                    {msg.role === 'assistant' ? (
+                      <AiMarkdown
+                        content={msg.content}
+                        citationMax={lastSearch ? Math.min(3, lastSearch.results.length) : undefined}
+                      />
+                    ) : (
+                      msg.content
+                    )}
                   </div>
                   {/* Show model metadata for assistant messages */}
                   {msg.role === 'assistant' && msg.model && (

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -5,6 +5,7 @@ import { ExternalLink, Star, Clock, Sparkles, Download, FileJson, FileSpreadshee
 import type { SearchResult } from '../../hooks/useSearch'
 import { useSavedResearch } from '../../hooks/useSavedResearch'
 import { explorerTxUrl, truncateHash } from '../../lib/stellar'
+import { AiMarkdown } from '../ai/AiMarkdown'
 
 interface Props {
   results: SearchResult[]
@@ -315,10 +316,10 @@ export function SearchResults({ results, query, isLoading, txHash }: Props) {
             {summaryError ? (
               <p className="text-red-300 text-xs">⚠ {summaryError}</p>
             ) : (
-              <p className="text-white/70 text-xs leading-relaxed whitespace-pre-wrap">
-                {summary}
+              <div className="text-white/70 text-xs leading-relaxed">
+                <AiMarkdown content={summary} citationMax={Math.min(5, results.length)} />
                 {summarizing && <span className="text-neon-cyan/60">▌</span>}
-              </p>
+              </div>
             )}
           </motion.div>
         )}
@@ -327,6 +328,8 @@ export function SearchResults({ results, query, isLoading, txHash }: Props) {
       {results.map((r, i) => (
         <motion.a
           key={r.id}
+          id={i < 5 ? `result-card-${i + 1}` : undefined}
+          tabIndex={-1}
           href={r.url}
           target="_blank"
           rel="noopener noreferrer"
@@ -335,7 +338,7 @@ export function SearchResults({ results, query, isLoading, txHash }: Props) {
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: i * 0.06 }}
-          className="block group rounded-xl p-4 hover:border-neon-cyan/25 transition-all relative"
+          className="block group rounded-xl p-4 hover:border-neon-cyan/25 transition-all relative focus:outline-none focus:ring-2 focus:ring-neon-cyan/60"
           style={{
             background: 'rgba(6,13,20,0.6)',
             border: '1px solid rgba(255,255,255,0.06)',


### PR DESCRIPTION
## Summary

Closes #166.

AI assistant text (Groq chat replies and the search-results summary) was being rendered as plain, unparsed text — no Markdown formatting, and numbered citations like `[1]` were inert. This PR adds a sanitized, dependency-free Markdown renderer and wires up citation → result-card linking.

- **`src/components/ai/AiMarkdown.tsx`** — a new renderer for a restricted Markdown subset (headings, bold/italic, inline code, fenced code blocks, unordered/ordered lists, `[text](https://...)` links). It builds React elements directly from a hand-written tokenizer — there is no `dangerouslySetInnerHTML` anywhere in the component, so raw HTML in AI output is always treated as literal text and can never execute.
- Numbered citations (`[1]`, `[2]`, …) are rendered as buttons. Clicking one scrolls to and focuses the matching result card (`#result-card-N`) in `SearchResults`. Citation numbers outside the known result range are left as plain, non-interactive text.
- **`src/components/search/SearchResults.tsx`** — result cards now expose stable `id="result-card-N"` (for the first 5, matching how many results the AI summary prompt is given) and are focusable (`tabIndex={-1}` + a visible focus ring) so citation clicks can jump to them. The AI summary block now renders through `AiMarkdown`.
- **`src/components/ai/GroqAssistant.tsx`** — assistant chat messages now render through `AiMarkdown` too, with `citationMax` derived from the injected search-context result count, so behavior is consistent wherever assistant text is shown.

This is a browser/UI-only concern, so Express, Vercel, and MCP runtime behavior are unaffected; no server-side changes were needed.

## Test plan
- [x] Added `src/components/ai/AiMarkdown.test.tsx` covering: bold/italic/code rendering, that raw `<img onerror>`-style markup is never injected as DOM/executed, list/heading rendering, safe link attributes, valid citation click-through, out-of-range citations staying as text, and the no-handler fallback that focuses `#result-card-N`.
- [x] `npm run build` (tsc + vite build) succeeds.
- [x] `npx vitest run` — full suite passes (207/207 tests, 17 files).