### PR TITLE
feat: reconcile facilitator settlements with paid provider requests (#315)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage/
 sbom.cyclonedx.json
 osv-results.json
 osv-results.sarif
+logs/

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ npm run config:check
 The typed schema checks required core variables separately from optional feature variables, plus Stellar network enums, public-key addresses, HTTP(S) URLs, ports, rate limits, and the USDC/stroop amount relationship. The browser receives only `VITE_STELLAR_NETWORK` and `VITE_SERVER_URL`; secrets never enter the browser configuration view.
 | `VITE_SERVER_URL` | No | `http://localhost:3001` | Frontend URL for AI chat backend calls. On Vercel deployments auto-detects `${origin}/api`; locally falls back to `http://localhost:3001`. | `http://localhost:3001` |
 | `MCP_ENABLE_RECEIPTS` | No | `0` | Set `1` to opt-in MCP local receipt storage for `stellar-search://receipts/recent` (in-memory capped at 50) | `1` |
+| `RECONCILIATION_LOG_PATH` | No | `logs/reconciliation.jsonl` | Path to the append-only settlement reconciliation log (see [Settlement reconciliation](#settlement-reconciliation)). | `/var/log/stellarsearch/reconciliation.jsonl` |
 
 ---
 
@@ -170,6 +171,31 @@ sequenceDiagram
     Serper-->>Server: Real Google search results
     Server-->>Browser: 200 OK + results + txHash
     Browser-->>User: Display paid search results
+```
+
+### Settlement reconciliation
+
+Every paid `/search`, `/images`, and `/news` request writes a
+`ReconciliationRecord` (`src/lib/reconciliation.ts`) to an append-only JSON
+Lines log (`server/reconciliationStore.ts`, default `logs/reconciliation.jsonl`,
+configurable via `RECONCILIATION_LOG_PATH`). Each record links the request's
+idempotency key (the payment identifier from `src/lib/paymentIntegrity.ts`),
+its settlement receipt (tx hash), and whether a provider response was
+delivered — **never the query text itself** — so operators can catch two
+kinds of drift:
+
+- `settled_no_delivery` — payment was consumed but no search response was
+  delivered (upstream Serper error, a validation failure after the payment
+  gate, etc.)
+- `delivered_no_settlement` — a response was returned without a captured
+  payment identifier (shouldn't happen given the x402 gate; catches
+  regressions)
+
+Run the repeatable reconciliation job to report unmatched or inconsistent
+records (exits non-zero when any are found, so it can run on a schedule):
+
+```bash
+npm run reconcile:report
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:search": "npm run search:cli -- \"Stellar blockchain\" --mode search",
     "test:quote": "npm run search:cli -- \"Stellar blockchain\" --mode quote --json",
     "test:suggestions": "npm run search:cli -- \"Stellar blockchain\" --mode search --count 3",
+    "reconcile:report": "tsx scripts/reconcile-report.ts",
     "deploy": "npm run build && vercel --prod"
   },
   "dependencies": {

--- a/scripts/reconcile-report.ts
+++ b/scripts/reconcile-report.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env tsx
+/**
+ * Repeatable reconciliation job.
+ *
+ * Reads the append-only reconciliation log (server/reconciliationStore.ts —
+ * one JSON line per paid /search, /images, or /news request) and reports
+ * requests where a settled payment has no matching delivered response, or a
+ * response was delivered without a captured settlement. Never prints query
+ * content — ReconciliationRecord doesn't carry it.
+ *
+ * Usage:  npm run reconcile:report [-- --path <logfile>]
+ * Exit code is 1 when unmatched records are found, so this can run on a
+ * schedule (cron / CI) and alert on non-zero exit.
+ */
+import { readReconciliationRecords, DEFAULT_RECONCILIATION_LOG_PATH } from '../server/reconciliationStore.js'
+import { summarizeReconciliation } from '../src/lib/reconciliation.js'
+
+function parseLogPath(argv: string[]): string {
+  const idx = argv.indexOf('--path')
+  return idx !== -1 && argv[idx + 1] ? argv[idx + 1] : DEFAULT_RECONCILIATION_LOG_PATH
+}
+
+function main(): void {
+  const logPath = parseLogPath(process.argv.slice(2))
+  const records = readReconciliationRecords(logPath)
+  const report = summarizeReconciliation(records)
+
+  console.log(`Reconciliation report — ${logPath}`)
+  console.log(`  total records:            ${report.total}`)
+  console.log(`  reconciled:               ${report.reconciled}`)
+  console.log(`  settled, no delivery:     ${report.settledNoDelivery}`)
+  console.log(`  delivered, no settlement: ${report.deliveredNoSettlement}`)
+
+  if (report.unmatched.length > 0) {
+    console.log('\nUnmatched records:')
+    for (const r of report.unmatched) {
+      console.log(
+        `  [${r.outcome}] requestId=${r.requestId} route=${r.route} idempotencyKey=${r.idempotencyKey ?? '(none)'} txHash=${r.receiptTxHash ?? '(none)'} resultCount=${r.resultCount} at=${r.createdAt}`
+      )
+    }
+    process.exitCode = 1
+  } else {
+    console.log('\nNo unmatched or inconsistent records. ✓')
+  }
+}
+
+main()

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,8 +24,37 @@ import { paymentMiddlewareFromConfig } from '@x402/express'
 import { ExactStellarScheme } from '@x402/stellar/exact/server'
 import { HTTPFacilitatorClient } from '@x402/core/server'
 import logger from './logger'
-import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
+import crypto, { randomUUID } from 'crypto'
+import {
+  STELLAR_NETWORK,
+  AMOUNT_USDC,
+  AMOUNT_STROOPS,
+  USDC_CONTRACT
+} from '../src/lib/constants'
+import { consumePaymentPayload, extractPaymentIdentifier } from '../src/lib/paymentIntegrity'
 import { formatConfigurationError, readServerConfig } from '../src/lib/config'
+import {
+  normalizeOrganicResults,
+  normalizeImageResults,
+  normalizeNewsResults,
+  normalizeQueryMetadata,
+} from '../src/lib/serperNormalizer.js'
+import type {
+  SearchResponse,
+  ImageSearchResponse,
+  NewsSearchResponse,
+  ApiErrorResponse,
+  BatchJsonlEvent,
+  BatchJsonlQuoteEvent,
+  BatchJsonlSettlementEvent,
+  BatchJsonlResultEvent,
+  BatchJsonlErrorEvent,
+  BatchJsonlDoneEvent,
+  SearchJob,
+  JobStatus,
+} from '../src/types/index.js'
+import { buildReconciliationRecord, type ReconciliationRoute } from '../src/lib/reconciliation.js'
+import { appendReconciliationRecord } from './reconciliationStore.js'
 
 dotenv.config()
 
@@ -327,10 +356,43 @@ app.use((req, res, next) => {
       if (!consumption.ok) {
         return res.status(402).json({ error: consumption.error })
       }
+      // Captured for reconciliation — links this request to the settled
+      // payment identifier without ever touching query content.
+      ;(req as any).paymentId = consumption.paymentId
     }
   }
   next()
 })
+
+// Builds and persists a ReconciliationRecord for a paid route. Never throws —
+// a logging failure must not affect the response already sent to the client.
+function recordReconciliation(params: {
+  req: Request
+  route: ReconciliationRoute
+  requestId: string
+  providerDelivered: boolean
+  resultCount: number
+  txHash: string | null
+}): void {
+  try {
+    const idempotencyKey = (params.req as any).paymentId ?? null
+    // Nothing to reconcile: no payment was captured and nothing was
+    // delivered (e.g. a bad `q` rejected before any payment attempt).
+    if (idempotencyKey === null && !params.providerDelivered) return
+
+    const record = buildReconciliationRecord({
+      requestId: params.requestId,
+      idempotencyKey,
+      route: params.route,
+      receiptTxHash: params.txHash,
+      providerDelivered: params.providerDelivered,
+      resultCount: params.resultCount,
+    })
+    appendReconciliationRecord(record)
+  } catch (err: any) {
+    console.error('[reconciliation] failed to record:', err.message)
+  }
+}
 
 export const MAX_QUERY_LENGTH = 256
 
@@ -357,18 +419,23 @@ export function validateQuery(
 
 // ─── GET /search ──────────────────────────────────────────────────────────
 app.get('/search', async (req: Request, res: Response) => {
-  const { q, count = '5', freshness } = req.query as Record<string, string>
-
-  const v = validateQuery(q)
-  if (!v.ok) {
-    const errorBody: ApiErrorResponse = { error: v.error }
-    return res.status(400).json(errorBody)
-  }
-  const cleanQ = v.cleanQ
-
-  const t0 = Date.now()
+  const requestId = randomUUID()
+  let providerDelivered = false
+  let resultCount = 0
+  let txHash: string | null = null
 
   try {
+    const { q, count = '5', freshness } = req.query as Record<string, string>
+
+    const v = validateQuery(q)
+    if (!v.ok) {
+      const errorBody: ApiErrorResponse = { error: v.error }
+      return res.status(400).json(errorBody)
+    }
+    const cleanQ = v.cleanQ
+
+    const t0 = Date.now()
+
     const requestBody: Record<string, unknown> = {
       q: cleanQ,
       num: Math.min(parseInt(count) || 5, 20),
@@ -414,7 +481,7 @@ app.get('/search', async (req: Request, res: Response) => {
     const queryMeta = normalizeQueryMetadata(data, cleanQ)
 
     // The real tx hash comes from the X-PAYMENT-RESPONSE header set by the facilitator
-    const txHash = (req.headers['x-payment-response'] as string) || null
+    txHash = (req.headers['x-payment-response'] as string) || null
 
     // ── Optional AI suggestions via Groq ──────────────────────────────────
     let suggestions: string[] = []
@@ -475,28 +542,37 @@ app.get('/search', async (req: Request, res: Response) => {
       // ignore receipt recording failure
     }
 
+    providerDelivered = true
+    resultCount = results.length
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[search error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'Search failed. Check server logs.' }
     return res.status(500).json(errorBody)
+  } finally {
+    recordReconciliation({ req, route: '/search', requestId, providerDelivered, resultCount, txHash })
   }
 })
 
 // ─── GET /images ──────────────────────────────────────────────────────────
 app.get('/images', async (req: Request, res: Response) => {
-  const { q, count = '10' } = req.query as Record<string, string>
-
-  const v = validateQuery(q)
-  if (!v.ok) {
-    const errorBody: ApiErrorResponse = { error: v.error }
-    return res.status(400).json(errorBody)
-  }
-  const cleanQ = v.cleanQ
-
-  const t0 = Date.now()
+  const requestId = randomUUID()
+  let providerDelivered = false
+  let resultCount = 0
+  let txHash: string | null = null
 
   try {
+    const { q, count = '10' } = req.query as Record<string, string>
+
+    const v = validateQuery(q)
+    if (!v.ok) {
+      const errorBody: ApiErrorResponse = { error: v.error }
+      return res.status(400).json(errorBody)
+    }
+    const cleanQ = v.cleanQ
+
+    const t0 = Date.now()
+
     const serperRes = await fetch('https://google.serper.dev/images', {
       method: 'POST',
       headers: {
@@ -526,7 +602,7 @@ app.get('/images', async (req: Request, res: Response) => {
 
     const results = normalizeImageResults(data)
 
-    const txHash = (req.headers['x-payment-response'] as string) || null
+    txHash = (req.headers['x-payment-response'] as string) || null
 
     const responseBody: ImageSearchResponse = {
       query: cleanQ,
@@ -539,28 +615,37 @@ app.get('/images', async (req: Request, res: Response) => {
       latencyMs,
     }
 
+    providerDelivered = true
+    resultCount = results.length
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[images error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'Image search failed. Check server logs.' }
     return res.status(500).json(errorBody)
+  } finally {
+    recordReconciliation({ req, route: '/images', requestId, providerDelivered, resultCount, txHash })
   }
 })
 
 // ─── GET /news ────────────────────────────────────────────────────────────
 app.get('/news', async (req: Request, res: Response) => {
-  const { q, count = '10', freshness } = req.query as Record<string, string>
-
-  const v = validateQuery(q)
-  if (!v.ok) {
-    const errorBody: ApiErrorResponse = { error: v.error }
-    return res.status(400).json(errorBody)
-  }
-  const cleanQ = v.cleanQ
-
-  const t0 = Date.now()
+  const requestId = randomUUID()
+  let providerDelivered = false
+  let resultCount = 0
+  let txHash: string | null = null
 
   try {
+    const { q, count = '10', freshness } = req.query as Record<string, string>
+
+    const v = validateQuery(q)
+    if (!v.ok) {
+      const errorBody: ApiErrorResponse = { error: v.error }
+      return res.status(400).json(errorBody)
+    }
+    const cleanQ = v.cleanQ
+
+    const t0 = Date.now()
+
     const requestBody: Record<string, unknown> = {
       q: cleanQ,
       num: Math.min(parseInt(count) || 10, 20),
@@ -603,7 +688,7 @@ app.get('/news', async (req: Request, res: Response) => {
 
     const results = normalizeNewsResults(data)
 
-    const txHash = (req.headers['x-payment-response'] as string) || null
+    txHash = (req.headers['x-payment-response'] as string) || null
 
     const responseBody: NewsSearchResponse = {
       query: cleanQ,
@@ -616,11 +701,15 @@ app.get('/news', async (req: Request, res: Response) => {
       latencyMs,
     }
 
+    providerDelivered = true
+    resultCount = results.length
     return res.json(responseBody)
   } catch (err: any) {
     console.error('[news error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'News search failed. Check server logs.' }
     return res.status(500).json(errorBody)
+  } finally {
+    recordReconciliation({ req, route: '/news', requestId, providerDelivered, resultCount, txHash })
   }
 })
 

--- a/server/reconciliation.integration.test.ts
+++ b/server/reconciliation.integration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * server/reconciliation.integration.test.ts
+ *
+ * Verifies /search, /images, /news actually persist ReconciliationRecord
+ * entries to the JSONL log as requests flow through the Express app —
+ * settled+delivered, settled+failed-upstream, and unpaid-and-rejected.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import request from 'supertest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+vi.mock('@x402/express', () => ({
+  paymentMiddlewareFromConfig: () => (_req: any, _res: any, next: any) => next(),
+}))
+vi.mock('@x402/core/server', () => ({
+  HTTPFacilitatorClient: class { constructor(_opts: any) {} },
+}))
+vi.mock('@x402/stellar/exact/server', () => ({
+  ExactStellarScheme: class { constructor() {} },
+}))
+vi.mock('groq-sdk', () => ({
+  default: class {
+    chat = { completions: { create: vi.fn() } }
+  },
+}))
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+process.env.STELLAR_RECEIVING_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+process.env.SERPER_API_KEY = 'test-serper-key'
+process.env.GROQ_API_KEY = 'gsk_test'
+
+function makeReceipt(txHash: string): string {
+  return Buffer.from(JSON.stringify({ transactionHash: txHash })).toString('base64')
+}
+
+let app: any
+let tmpDir: string
+let logPath: string
+
+beforeEach(async () => {
+  vi.resetModules()
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconciliation-integration-'))
+  logPath = path.join(tmpDir, 'reconciliation.jsonl')
+  process.env.RECONCILIATION_LOG_PATH = logPath
+
+  const { resetConsumedPayments } = await import('../src/lib/paymentIntegrity')
+  resetConsumedPayments()
+
+  const mod = await import('./index.js')
+  app = mod.default
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ organic: [{ title: 'Stellar', link: 'https://stellar.org', snippet: 'desc' }] }),
+  } as any)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete process.env.RECONCILIATION_LOG_PATH
+  if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function readLog(): any[] {
+  if (!fs.existsSync(logPath)) return []
+  return fs
+    .readFileSync(logPath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map(l => JSON.parse(l))
+}
+
+describe('reconciliation wiring — /search, /images, /news', () => {
+  it('records a reconciled entry for a settled, delivered /search request', async () => {
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_recon_ok'))
+    expect(res.status).toBe(200)
+
+    const records = readLog()
+    expect(records).toHaveLength(1)
+    expect(records[0].outcome).toBe('reconciled')
+    expect(records[0].route).toBe('/search')
+    expect(records[0].paymentSettled).toBe(true)
+    expect(records[0].providerDelivered).toBe(true)
+    expect(records[0].resultCount).toBe(1)
+    expect(records[0].idempotencyKey).toMatch(/^tx:tx_recon_ok$/)
+  })
+
+  it('records settled_no_delivery when payment succeeds but Serper errors', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => 'boom' } as any)
+    const res = await request(app).get('/search?q=stellar').set('x-payment', makeReceipt('tx_recon_fail'))
+    expect(res.status).toBe(502)
+
+    const records = readLog()
+    expect(records).toHaveLength(1)
+    expect(records[0].outcome).toBe('settled_no_delivery')
+    expect(records[0].providerDelivered).toBe(false)
+  })
+
+  it('does not record anything for an unpaid, rejected request (nothing to reconcile)', async () => {
+    const res = await request(app).get('/search')
+    expect(res.status).toBe(400)
+    expect(readLog()).toHaveLength(0)
+  })
+
+  it('records reconciled entries for /images and /news too', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ images: [{ title: 'Img', imageUrl: 'https://i.example.com/1.jpg', link: 'https://example.com' }] }),
+    } as any)
+    await request(app).get('/images?q=stellar').set('x-payment', makeReceipt('tx_recon_img'))
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ news: [{ title: 'News', link: 'https://news.example.com', snippet: 'x' }] }),
+    } as any)
+    await request(app).get('/news?q=stellar').set('x-payment', makeReceipt('tx_recon_news'))
+
+    const records = readLog()
+    expect(records.map(r => r.route).sort()).toEqual(['/images', '/news'])
+    expect(records.every(r => r.outcome === 'reconciled')).toBe(true)
+  })
+
+  it('never writes query content into the reconciliation log', async () => {
+    await request(app).get('/search?q=super-secret-research-topic').set('x-payment', makeReceipt('tx_recon_privacy'))
+    const raw = fs.readFileSync(logPath, 'utf8')
+    expect(raw).not.toContain('super-secret-research-topic')
+  })
+})

--- a/server/reconciliationStore.test.ts
+++ b/server/reconciliationStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { appendReconciliationRecord, readReconciliationRecords } from './reconciliationStore'
+import { buildReconciliationRecord } from '../src/lib/reconciliation'
+
+let tmpDir: string
+
+afterEach(() => {
+  if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function makeLogPath(): string {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconciliation-test-'))
+  return path.join(tmpDir, 'reconciliation.jsonl')
+}
+
+describe('reconciliationStore', () => {
+  it('returns an empty array when the log file does not exist yet', () => {
+    const logPath = makeLogPath()
+    expect(readReconciliationRecords(logPath)).toEqual([])
+  })
+
+  it('creates the log directory and appends one JSON line per record', () => {
+    const logPath = makeLogPath()
+    const record = buildReconciliationRecord({
+      requestId: 'req-1',
+      idempotencyKey: 'tx:abc',
+      route: '/search',
+      receiptTxHash: 'abc',
+      providerDelivered: true,
+      resultCount: 3,
+    })
+
+    appendReconciliationRecord(record, logPath)
+    const raw = fs.readFileSync(logPath, 'utf8')
+    expect(raw.trim().split('\n')).toHaveLength(1)
+
+    const [read] = readReconciliationRecords(logPath)
+    expect(read).toEqual(record)
+  })
+
+  it('reads back multiple appended records in order', () => {
+    const logPath = makeLogPath()
+    const r1 = buildReconciliationRecord({ requestId: 'a', idempotencyKey: 'tx:a', route: '/search', receiptTxHash: 'a', providerDelivered: true, resultCount: 1 })
+    const r2 = buildReconciliationRecord({ requestId: 'b', idempotencyKey: 'tx:b', route: '/images', receiptTxHash: null, providerDelivered: false, resultCount: 0 })
+
+    appendReconciliationRecord(r1, logPath)
+    appendReconciliationRecord(r2, logPath)
+
+    const records = readReconciliationRecords(logPath)
+    expect(records.map(r => r.requestId)).toEqual(['a', 'b'])
+    expect(records[1].outcome).toBe('settled_no_delivery')
+  })
+
+  it('skips blank lines', () => {
+    const logPath = makeLogPath()
+    fs.mkdirSync(path.dirname(logPath), { recursive: true })
+    fs.writeFileSync(logPath, '\n\n')
+    expect(readReconciliationRecords(logPath)).toEqual([])
+  })
+})

--- a/server/reconciliationStore.ts
+++ b/server/reconciliationStore.ts
@@ -1,0 +1,31 @@
+import fs from 'fs'
+import path from 'path'
+import type { ReconciliationRecord } from '../src/lib/reconciliation.js'
+
+/**
+ * Append-only JSON-lines log of ReconciliationRecord entries. Deliberately
+ * a plain file rather than the in-memory paymentIntegrity store: it must
+ * survive process restarts so the reconcile:report job (scripts/reconcile-report.ts)
+ * can be run repeatably, independent of server uptime.
+ */
+export const DEFAULT_RECONCILIATION_LOG_PATH =
+  process.env.RECONCILIATION_LOG_PATH || path.join(process.cwd(), 'logs', 'reconciliation.jsonl')
+
+export function appendReconciliationRecord(
+  record: ReconciliationRecord,
+  logPath: string = DEFAULT_RECONCILIATION_LOG_PATH,
+): void {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true })
+  fs.appendFileSync(logPath, JSON.stringify(record) + '\n')
+}
+
+export function readReconciliationRecords(
+  logPath: string = DEFAULT_RECONCILIATION_LOG_PATH,
+): ReconciliationRecord[] {
+  if (!fs.existsSync(logPath)) return []
+  return fs
+    .readFileSync(logPath, 'utf8')
+    .split('\n')
+    .filter(line => line.trim().length > 0)
+    .map(line => JSON.parse(line) as ReconciliationRecord)
+}

--- a/src/lib/reconciliation.test.ts
+++ b/src/lib/reconciliation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyOutcome,
+  buildReconciliationRecord,
+  summarizeReconciliation,
+  type ReconciliationRecord,
+} from './reconciliation'
+
+describe('classifyOutcome', () => {
+  it('marks settled + delivered as reconciled', () => {
+    expect(classifyOutcome(true, true)).toBe('reconciled')
+  })
+
+  it('marks settled + not delivered as settled_no_delivery', () => {
+    expect(classifyOutcome(true, false)).toBe('settled_no_delivery')
+  })
+
+  it('marks not settled + delivered as delivered_no_settlement', () => {
+    expect(classifyOutcome(false, true)).toBe('delivered_no_settlement')
+  })
+})
+
+describe('buildReconciliationRecord', () => {
+  it('derives paymentSettled from a non-null idempotencyKey', () => {
+    const record = buildReconciliationRecord({
+      requestId: 'req-1',
+      idempotencyKey: 'tx:abc123',
+      route: '/search',
+      receiptTxHash: 'abc123',
+      providerDelivered: true,
+      resultCount: 5,
+      now: new Date('2026-01-01T00:00:00Z'),
+    })
+    expect(record.paymentSettled).toBe(true)
+    expect(record.outcome).toBe('reconciled')
+    expect(record.createdAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('derives paymentSettled=false from a null idempotencyKey', () => {
+    const record = buildReconciliationRecord({
+      requestId: 'req-2',
+      idempotencyKey: null,
+      route: '/images',
+      receiptTxHash: null,
+      providerDelivered: true,
+      resultCount: 2,
+    })
+    expect(record.paymentSettled).toBe(false)
+    expect(record.outcome).toBe('delivered_no_settlement')
+  })
+
+  it('never includes query content — only identifiers, booleans, counts, timestamps', () => {
+    const record = buildReconciliationRecord({
+      requestId: 'req-3',
+      idempotencyKey: 'tx:xyz',
+      route: '/news',
+      receiptTxHash: 'xyz',
+      providerDelivered: false,
+      resultCount: 0,
+    })
+    expect(Object.keys(record).sort()).toEqual(
+      [
+        'requestId',
+        'idempotencyKey',
+        'route',
+        'receiptTxHash',
+        'paymentSettled',
+        'providerDelivered',
+        'resultCount',
+        'outcome',
+        'createdAt',
+      ].sort()
+    )
+  })
+})
+
+describe('summarizeReconciliation', () => {
+  const base = {
+    route: '/search' as const,
+    receiptTxHash: null,
+    resultCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  const records: ReconciliationRecord[] = [
+    { ...base, requestId: '1', idempotencyKey: 'tx:1', paymentSettled: true, providerDelivered: true, outcome: 'reconciled' },
+    { ...base, requestId: '2', idempotencyKey: 'tx:2', paymentSettled: true, providerDelivered: false, outcome: 'settled_no_delivery' },
+    { ...base, requestId: '3', idempotencyKey: null, paymentSettled: false, providerDelivered: true, outcome: 'delivered_no_settlement' },
+    { ...base, requestId: '4', idempotencyKey: 'tx:4', paymentSettled: true, providerDelivered: true, outcome: 'reconciled' },
+  ]
+
+  it('counts each outcome bucket correctly', () => {
+    const report = summarizeReconciliation(records)
+    expect(report.total).toBe(4)
+    expect(report.reconciled).toBe(2)
+    expect(report.settledNoDelivery).toBe(1)
+    expect(report.deliveredNoSettlement).toBe(1)
+  })
+
+  it('collects every non-reconciled record as unmatched', () => {
+    const report = summarizeReconciliation(records)
+    expect(report.unmatched.map(r => r.requestId).sort()).toEqual(['2', '3'])
+  })
+
+  it('returns an empty report for no records', () => {
+    const report = summarizeReconciliation([])
+    expect(report).toEqual({ total: 0, reconciled: 0, settledNoDelivery: 0, deliveredNoSettlement: 0, unmatched: [] })
+  })
+})

--- a/src/lib/reconciliation.ts
+++ b/src/lib/reconciliation.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure reconciliation logic shared by every runtime (Express, Vercel, MCP).
+ *
+ * A ReconciliationRecord links a single paid request's idempotency key
+ * (the payment identifier from src/lib/paymentIntegrity.ts) and settlement
+ * receipt (tx hash) to whether a provider response was actually delivered,
+ * so operators can spot two kinds of drift:
+ *   - settled_no_delivery    — payment was consumed but no search response
+ *                               was delivered (upstream error, validation
+ *                               failure after the payment gate, etc.)
+ *   - delivered_no_settlement — a response was returned without a captured
+ *                               payment identifier (should never happen
+ *                               given the x402 gate; catches regressions)
+ *
+ * Records intentionally never carry the search query text or any other
+ * user-supplied content — only identifiers, booleans, counts, and
+ * timestamps — so a reconciliation report is safe to store or forward
+ * without exposing query content.
+ */
+
+export type ReconciliationRoute = '/search' | '/images' | '/news'
+
+export type ReconciliationOutcome =
+  | 'reconciled'
+  | 'settled_no_delivery'
+  | 'delivered_no_settlement'
+
+export interface ReconciliationRecord {
+  requestId: string
+  /** Payment identifier from consumePaymentPayload(), or null if none was captured. */
+  idempotencyKey: string | null
+  route: ReconciliationRoute
+  /** Settlement transaction hash, when available. */
+  receiptTxHash: string | null
+  paymentSettled: boolean
+  providerDelivered: boolean
+  resultCount: number
+  outcome: ReconciliationOutcome
+  createdAt: string
+}
+
+export interface ReconciliationReport {
+  total: number
+  reconciled: number
+  settledNoDelivery: number
+  deliveredNoSettlement: number
+  /** Every non-`reconciled` record, for operator follow-up. */
+  unmatched: ReconciliationRecord[]
+}
+
+export function classifyOutcome(paymentSettled: boolean, providerDelivered: boolean): ReconciliationOutcome {
+  if (paymentSettled && providerDelivered) return 'reconciled'
+  if (paymentSettled && !providerDelivered) return 'settled_no_delivery'
+  return 'delivered_no_settlement'
+}
+
+export function buildReconciliationRecord(params: {
+  requestId: string
+  idempotencyKey: string | null
+  route: ReconciliationRoute
+  receiptTxHash: string | null
+  providerDelivered: boolean
+  resultCount: number
+  now?: Date
+}): ReconciliationRecord {
+  const paymentSettled = params.idempotencyKey !== null
+  const outcome = classifyOutcome(paymentSettled, params.providerDelivered)
+
+  return {
+    requestId: params.requestId,
+    idempotencyKey: params.idempotencyKey,
+    route: params.route,
+    receiptTxHash: params.receiptTxHash,
+    paymentSettled,
+    providerDelivered: params.providerDelivered,
+    resultCount: params.resultCount,
+    outcome,
+    createdAt: (params.now ?? new Date()).toISOString(),
+  }
+}
+
+export function summarizeReconciliation(records: ReconciliationRecord[]): ReconciliationReport {
+  const unmatched = records.filter(r => r.outcome !== 'reconciled')
+  return {
+    total: records.length,
+    reconciled: records.length - unmatched.length,
+    settledNoDelivery: records.filter(r => r.outcome === 'settled_no_delivery').length,
+    deliveredNoSettlement: records.filter(r => r.outcome === 'delivered_no_settlement').length,
+    unmatched,
+  }
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["scripts/**/*", "src/lib/**/*", "src/types/**/*"],
+  "include": ["scripts/**/*", "src/lib/**/*", "src/types/**/*", "server/reconciliationStore.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Closes #315.

Operators currently have no way to detect two kinds of payment/delivery drift on the paid `/search`, `/images`, and `/news` routes: a settled x402 payment where the search response was never delivered (upstream Serper error, a validation failure that slips past the payment gate, etc.), or — defensively — a delivered response with no captured settlement. This adds a reconciliation record for every paid request and a repeatable job to report on it.

- **`src/lib/reconciliation.ts`** (shared, pure, runtime-agnostic) — defines `ReconciliationRecord`, classifies each request as `reconciled` / `settled_no_delivery` / `delivered_no_settlement`, and summarizes a batch of records into a report. Records intentionally never carry query text or any other user-supplied content — only identifiers, booleans, counts, and timestamps.
- **`server/reconciliationStore.ts`** — append-only JSON-lines persistence (`logs/reconciliation.jsonl` by default, overridable via `RECONCILIATION_LOG_PATH`), so the reconciliation job can run independently of server uptime rather than depending on in-memory state.
- **`server/index.ts`** — the payment-replay-protection middleware now captures the payment identifier from `consumePaymentPayload()` onto the request; `/search`, `/images`, and `/news` are wrapped in `try/finally` so every exit path (success, upstream error, post-payment validation failure, thrown exception) writes a reconciliation record linking `requestId`, idempotency key, receipt (tx hash), and delivery outcome. Unpaid-and-rejected requests (e.g. a bad `q` with no payment header at all) are skipped — there's nothing to reconcile there.
- **`scripts/reconcile-report.ts`** — the repeatable job (`npm run reconcile:report`). Reads the log, prints a summary, and exits non-zero when unmatched/inconsistent records are found, so it's safe to run on a schedule (cron, CI) and alert on non-zero exit.

## Test plan
- [x] `src/lib/reconciliation.test.ts` — classification and summary logic, including an explicit check that a record's keys never include anything beyond identifiers/booleans/counts/timestamps (no query content).
- [x] `server/reconciliationStore.test.ts` — JSONL append/read round-tripping, missing-file handling, blank-line tolerance.
- [x] `server/reconciliation.integration.test.ts` — end-to-end through the real Express app for all three routes: reconciled (paid + delivered), `settled_no_delivery` (paid, upstream Serper failure), skip-on-unpaid-rejection (no payment header, 400 before the payment gate would ever apply), and a check that the search query text never reaches the log file.
- [x] `npm run typecheck:all`, `npm run lint`, `npx vitest run` (217/217 passing across 19 files), `npm run build` — all clean.
- [x] `npm run reconcile:report` — smoke-tested against an empty and a populated log.

This only touches the Express runtime (`server/`), matching the issue's listed relevant files; no behavior changed for `/ai/chat`, `/health`, or the Vercel serverless functions.