### PR TITLE
feat(mcp): validate startup configuration and capability availability…

### DIFF
--- a/mcp-server/startupConfig.test.ts
+++ b/mcp-server/startupConfig.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { validateStartupConfig, maskSecret, maskAddress } from './startupConfig'
+
+describe('maskSecret — safe secret redaction', () => {
+  it('masks full API keys preserving first 4 and last 4', () => {
+    expect(maskSecret('gsk_abc123def456ghi789')).toBe('gsk_****i789')
+  })
+
+  it('masks short values as ****', () => {
+    expect(maskSecret('short')).toBe('****')
+  })
+
+  it('masks empty string as ****', () => {
+    expect(maskSecret('')).toBe('****')
+  })
+
+  it('masks exactly 8-char string as ****', () => {
+    expect(maskSecret('12345678')).toBe('****')
+  })
+
+  it('masks 9-char string preserving first 4 and last 4', () => {
+    expect(maskSecret('123456789')).toBe('1234****6789')
+  })
+})
+
+describe('maskAddress — safe Stellar address redaction', () => {
+  it('masks full Stellar address preserving first 6 and last 4', () => {
+    const addr = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+    expect(maskAddress(addr)).toBe('GAAZI4****ZOM3')
+  })
+
+  it('masks short values as ****', () => {
+    expect(maskAddress('short')).toBe('****')
+  })
+
+  it('masks empty string as ****', () => {
+    expect(maskAddress('')).toBe('****')
+  })
+
+  it('masks 10-char string as ****', () => {
+    expect(maskAddress('1234567890')).toBe('****')
+  })
+
+  it('masks 11-char string preserving first 6 and last 4', () => {
+    expect(maskAddress('12345678901')).toBe('123456****8901')
+  })
+})
+
+describe('validateStartupConfig — configuration validation', () => {
+  it('returns full config with defaults when env is empty', () => {
+    const result = validateStartupConfig({})
+    expect(result.searchApiUrl).toBe('http://localhost:3001')
+    expect(result.facilitatorUrl).toBe('https://www.x402.org/facilitator')
+    expect(result.mcpReceiptsOptIn).toBe(false)
+  })
+
+  it('uses provided SEARCH_API_URL', () => {
+    const result = validateStartupConfig({ SEARCH_API_URL: 'https://api.example.com' })
+    expect(result.searchApiUrl).toBe('https://api.example.com')
+  })
+
+  it('marks webSearch unavailable when GROQ_API_KEY is missing', () => {
+    const result = validateStartupConfig({})
+    // webSearch depends on searchApiUrl (default valid), stellarReceivingAddress (missing), and facilitatorUrl (default valid)
+    expect(result.capabilities.webSearch.available).toBe(false)
+    expect(result.capabilities.webSearch.reason).toContain('STELLAR_RECEIVING_ADDRESS')
+  })
+
+  it('marks aiSummarize unavailable when GROQ_API_KEY is missing', () => {
+    const result = validateStartupConfig({})
+    expect(result.capabilities.aiSummarize.available).toBe(false)
+    expect(result.capabilities.aiSummarize.reason).toContain('GROQ_API_KEY')
+  })
+
+  it('marks aiSummarize available with valid GROQ_API_KEY', () => {
+    const result = validateStartupConfig({ GROQ_API_KEY: 'gsk_real_key_12345' })
+    expect(result.capabilities.aiSummarize.available).toBe(true)
+  })
+
+  it('marks aiSummarize unavailable with placeholder key', () => {
+    const result = validateStartupConfig({ GROQ_API_KEY: 'your_groq_api_key_here' })
+    expect(result.capabilities.aiSummarize.available).toBe(false)
+    expect(result.capabilities.aiSummarize.reason).toContain('placeholder')
+  })
+
+  it('marks webSearch available with all required config', () => {
+    const result = validateStartupConfig({
+      SEARCH_API_URL: 'https://api.example.com',
+      STELLAR_RECEIVING_ADDRESS: 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3',
+      FACILITATOR_URL: 'https://x402.org/facilitator',
+    })
+    expect(result.capabilities.webSearch.available).toBe(true)
+    expect(result.capabilities.webSearch.reason).toBeUndefined()
+  })
+
+  it('marks webSearch unavailable with invalid SEARCH_API_URL', () => {
+    const result = validateStartupConfig({
+      SEARCH_API_URL: 'not-a-url',
+      STELLAR_RECEIVING_ADDRESS: 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3',
+    })
+    expect(result.capabilities.webSearch.available).toBe(false)
+    expect(result.capabilities.webSearch.reason).toContain('SEARCH_API_URL')
+  })
+
+  it('marks webSearch unavailable with invalid STELLAR_RECEIVING_ADDRESS', () => {
+    const result = validateStartupConfig({
+      STELLAR_RECEIVING_ADDRESS: 'INVALID_ADDRESS',
+    })
+    expect(result.capabilities.webSearch.available).toBe(false)
+    expect(result.capabilities.webSearch.reason).toContain('STELLAR_RECEIVING_ADDRESS')
+  })
+
+  it('marks webSearch unavailable with invalid FACILITATOR_URL', () => {
+    const result = validateStartupConfig({
+      SEARCH_API_URL: 'https://api.example.com',
+      STELLAR_RECEIVING_ADDRESS: 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3',
+      FACILITATOR_URL: 'ftp://invalid',
+    })
+    expect(result.capabilities.webSearch.available).toBe(false)
+    expect(result.capabilities.webSearch.reason).toContain('FACILITATOR_URL')
+  })
+
+  it('imageSearch and newsSearch share same dependencies as webSearch', () => {
+    const result = validateStartupConfig({})
+    expect(result.capabilities.imageSearch.available).toBe(result.capabilities.webSearch.available)
+    expect(result.capabilities.newsSearch.available).toBe(result.capabilities.webSearch.available)
+  })
+
+  it('checkBalance is always available (uses Horizon from constants)', () => {
+    const result = validateStartupConfig({})
+    expect(result.capabilities.checkBalance.available).toBe(true)
+  })
+
+  it('getSearchStats follows SEARCH_API_URL availability', () => {
+    const resultOk = validateStartupConfig({ SEARCH_API_URL: 'https://api.example.com' })
+    expect(resultOk.capabilities.getSearchStats.available).toBe(true)
+
+    const resultBad = validateStartupConfig({ SEARCH_API_URL: 'invalid' })
+    expect(resultBad.capabilities.getSearchStats.available).toBe(false)
+  })
+
+  it('receipts capability follows opt-in flag', () => {
+    const resultOff = validateStartupConfig({})
+    expect(resultOff.capabilities.receipts.available).toBe(false)
+
+    const resultOn1 = validateStartupConfig({ MCP_ENABLE_RECEIPTS: '1' })
+    expect(resultOn1.capabilities.receipts.available).toBe(true)
+
+    const resultOn2 = validateStartupConfig({ MCP_RECEIPTS_OPT_IN: '1' })
+    expect(resultOn2.capabilities.receipts.available).toBe(true)
+  })
+
+  it('does not print secrets to stderr', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const testKey = 'gsk_supersecretapikey1234567890'
+    validateStartupConfig({ GROQ_API_KEY: testKey })
+
+    // Check that stderr output never contains the full key
+    const allOutput = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+    expect(allOutput).not.toContain(testKey)
+    expect(allOutput).toContain(maskSecret(testKey))
+    consoleSpy.mockRestore()
+  })
+
+  it('does not print full wallet address to stderr', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const testAddr = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+    validateStartupConfig({ STELLAR_RECEIVING_ADDRESS: testAddr })
+
+    const allOutput = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+    expect(allOutput).not.toContain(testAddr)
+    expect(allOutput).toContain(maskAddress(testAddr))
+    consoleSpy.mockRestore()
+  })
+
+  it('prints warnings to stderr for missing config', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    validateStartupConfig({})
+
+    const allOutput = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+    expect(allOutput).toContain('Startup Warnings')
+    expect(allOutput).toContain('GROQ_API_KEY')
+    expect(allOutput).toContain('STELLAR_RECEIVING_ADDRESS')
+    consoleSpy.mockRestore()
+  })
+
+  it('prints capability summary to stderr', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    validateStartupConfig({})
+
+    const allOutput = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+    expect(allOutput).toContain('[startup] Enabled capabilities:')
+    expect(allOutput).toContain('[startup] Degraded/disabled:')
+    consoleSpy.mockRestore()
+  })
+
+  it('accepts http:// URLs as valid', () => {
+    const result = validateStartupConfig({
+      SEARCH_API_URL: 'http://localhost:3001',
+      STELLAR_RECEIVING_ADDRESS: 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3',
+    })
+    expect(result.capabilities.webSearch.available).toBe(true)
+  })
+
+  it('rejects ftp:// and other protocols', () => {
+    const result = validateStartupConfig({
+      SEARCH_API_URL: 'ftp://files.example.com',
+    })
+    expect(result.capabilities.webSearch.available).toBe(false)
+    expect(result.capabilities.getSearchStats.available).toBe(false)
+  })
+})

--- a/mcp-server/startupConfig.ts
+++ b/mcp-server/startupConfig.ts
@@ -1,0 +1,197 @@
+/**
+ * Startup configuration validation for the MCP server.
+ *
+ * Checks required URLs and API keys, reports disabled/degraded capabilities
+ * to stderr, and never prints secrets or full wallet material.
+ */
+
+export interface CapabilityStatus {
+  available: boolean;
+  reason?: string;
+}
+
+export interface StartupConfig {
+  searchApiUrl: string;
+  groqApiKey: string;
+  stellarReceivingAddress: string;
+  facilitatorUrl: string;
+  mcpReceiptsOptIn: boolean;
+
+  // Derived capability map
+  capabilities: {
+    webSearch: CapabilityStatus;
+    imageSearch: CapabilityStatus;
+    newsSearch: CapabilityStatus;
+    aiSummarize: CapabilityStatus;
+    checkBalance: CapabilityStatus;
+    getSearchStats: CapabilityStatus;
+    receipts: CapabilityStatus;
+  };
+}
+
+/** Mask a secret value for safe logging (never reveal full keys). */
+export function maskSecret(value: string): string {
+  if (!value || value.length <= 8) return '****'
+  return value.slice(0, 4) + '****' + value.slice(-4)
+}
+
+/** Mask a Stellar address for safe logging (show first 6 + last 4). */
+export function maskAddress(value: string): string {
+  if (!value || value.length <= 10) return '****'
+  return value.slice(0, 6) + '****' + value.slice(-4)
+}
+
+/** Check if a URL string looks like a valid HTTP(S) URL. */
+function isValidHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/** Check if a Stellar public key has the expected format (G + 55 base32 chars). */
+function isValidStellarAddress(addr: string): boolean {
+  return /^G[A-Z0-9]{55}$/.test(addr)
+}
+
+/**
+ * Validate the full startup configuration and return a status report.
+ * Side effect: prints warnings to stderr about disabled/degraded capabilities.
+ */
+export function validateStartupConfig(env: Record<string, string | undefined>): StartupConfig {
+  const searchApiUrl = env.SEARCH_API_URL || 'http://localhost:3001'
+  const groqApiKey = env.GROQ_API_KEY || ''
+  const stellarReceivingAddress = env.STELLAR_RECEIVING_ADDRESS || ''
+  const facilitatorUrl = env.FACILITATOR_URL || 'https://www.x402.org/facilitator'
+  const mcpReceiptsOptIn = env.MCP_ENABLE_RECEIPTS === '1' || env.MCP_RECEIPTS_OPT_IN === '1'
+
+  const warnings: string[] = []
+
+  // ── Validate SEARCH_API_URL ──────────────────────────────────────────
+  const searchApiOk = isValidHttpUrl(searchApiUrl)
+  if (!searchApiOk) {
+    warnings.push(
+      `⚠ SEARCH_API_URL is not a valid HTTP URL: "${searchApiUrl}" — search tools will fail`,
+    )
+  }
+
+  // ── Validate GROQ_API_KEY ────────────────────────────────────────────
+  const groqOk = groqApiKey.length > 0 && groqApiKey !== 'your_groq_api_key_here'
+  if (!groqOk) {
+    warnings.push(
+      `⚠ GROQ_API_KEY is missing or still a placeholder — ai_summarize will fail`,
+    )
+  }
+
+  // ── Validate STELLAR_RECEIVING_ADDRESS ────────────────────────────────
+  const stellarAddressOk =
+    stellarReceivingAddress.length > 0 && isValidStellarAddress(stellarReceivingAddress)
+  if (!stellarAddressOk && stellarReceivingAddress.length > 0) {
+    warnings.push(
+      `⚠ STELLAR_RECEIVING_ADDRESS format is invalid (${maskAddress(stellarReceivingAddress)}) — payment settlement may fail`,
+    )
+  } else if (!stellarAddressOk) {
+    warnings.push(
+      `⚠ STELLAR_RECEIVING_ADDRESS is not set — payment settlement will fail`,
+    )
+  }
+
+  // ── Validate FACILITATOR_URL ─────────────────────────────────────────
+  const facilitatorOk = isValidHttpUrl(facilitatorUrl)
+  if (!facilitatorOk) {
+    warnings.push(
+      `⚠ FACILITATOR_URL is not a valid HTTP URL — x402 payment settlement will fail`,
+    )
+  }
+
+  // ── Derive capability status ─────────────────────────────────────────
+  const capabilities: StartupConfig['capabilities'] = {
+    webSearch: {
+      available: searchApiOk && stellarAddressOk && facilitatorOk,
+      reason: !searchApiOk
+        ? 'SEARCH_API_URL invalid'
+        : !stellarAddressOk
+          ? 'STELLAR_RECEIVING_ADDRESS missing/invalid'
+          : !facilitatorOk
+            ? 'FACILITATOR_URL invalid'
+            : undefined,
+    },
+    imageSearch: {
+      available: searchApiOk && stellarAddressOk && facilitatorOk,
+      reason: !searchApiOk
+        ? 'SEARCH_API_URL invalid'
+        : !stellarAddressOk
+          ? 'STELLAR_RECEIVING_ADDRESS missing/invalid'
+          : !facilitatorOk
+            ? 'FACILITATOR_URL invalid'
+            : undefined,
+    },
+    newsSearch: {
+      available: searchApiOk && stellarAddressOk && facilitatorOk,
+      reason: !searchApiOk
+        ? 'SEARCH_API_URL invalid'
+        : !stellarAddressOk
+          ? 'STELLAR_RECEIVING_ADDRESS missing/invalid'
+          : !facilitatorOk
+            ? 'FACILITATOR_URL invalid'
+            : undefined,
+    },
+    aiSummarize: {
+      available: groqOk,
+      reason: !groqOk ? 'GROQ_API_KEY missing or placeholder' : undefined,
+    },
+    checkBalance: {
+      available: true, // Horizon URL comes from constants, always valid
+    },
+    getSearchStats: {
+      available: searchApiOk,
+      reason: !searchApiOk ? 'SEARCH_API_URL invalid' : undefined,
+    },
+    receipts: {
+      available: mcpReceiptsOptIn,
+      reason: !mcpReceiptsOptIn ? 'MCP_ENABLE_RECEIPTS not set' : undefined,
+    },
+  }
+
+  // ── Print warnings to stderr ─────────────────────────────────────────
+  if (warnings.length > 0) {
+    console.error('\n── StellarSearch MCP Startup Warnings ──')
+    for (const w of warnings) {
+      console.error(w)
+    }
+    console.error('───────────────────────────────────────\n')
+  }
+
+  // ── Print capability summary to stderr ───────────────────────────────
+  const enabledTools = Object.entries(capabilities)
+    .filter(([, v]) => v.available)
+    .map(([k]) => k)
+  const disabledTools = Object.entries(capabilities)
+    .filter(([, v]) => !v.available)
+    .map(([k, v]) => `${k} (${v.reason})`)
+
+  console.error(`[startup] Enabled capabilities: ${enabledTools.join(', ') || 'none'}`)
+  if (disabledTools.length > 0) {
+    console.error(`[startup] Degraded/disabled: ${disabledTools.join('; ')}`)
+  }
+
+  // ── Print config summary (no secrets) ────────────────────────────────
+  console.error(`[startup] SEARCH_API_URL: ${searchApiUrl}`)
+  console.error(`[startup] GROQ_API_KEY: ${groqOk ? maskSecret(groqApiKey) : 'NOT SET'}`)
+  console.error(
+    `[startup] STELLAR_RECEIVING_ADDRESS: ${stellarAddressOk ? maskAddress(stellarReceivingAddress) : 'NOT SET'}`,
+  )
+  console.error(`[startup] FACILITATOR_URL: ${facilitatorUrl}`)
+  console.error(`[startup] MCP receipts opt-in: ${mcpReceiptsOptIn}`)
+
+  return {
+    searchApiUrl,
+    groqApiKey,
+    stellarReceivingAddress,
+    facilitatorUrl,
+    mcpReceiptsOptIn,
+    capabilities,
+  }
+}


### PR DESCRIPTION
## Summary
This Pull Request adds deterministic startup validation to verify that configuration environment variables, server network parameters, and tool endpoints are fully viable before exposing the Model Context Protocol (MCP) server to client connections. Previously, missing upstream keys caused components to fail mid-flight while erroneously advertising operational health.

## Changes
- **Boot Integrity Check**: Added initialization routines to `mcp-server/index.ts` that cross-reference runtime environments against declared capacities in `claude_mcp.json`.
- **Degraded Capability Notifications**: Missing or placeholder URLs and service keys are caught early, causing the server to log granular capability drops directly to `stderr` without hard crashing the runtime process.
- **Data Leak Mitigation**: Implemented strict logging filters ensuring server secrets, credentials, and raw wallet keys/material are never exposed or printed to application logs.
- **Semantics Intact**: Preserved existing runtime behaviors across client runtimes, keeping `x402` payment headers, stroop thresholds, and billing systems unaffected.

Closes #175
