### PR TITLE
feat: add configurable circuit breaker around Serper.dev calls (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ The typed schema checks required core variables separately from optional feature
 | `VITE_SERVER_URL` | No | `http://localhost:3001` | Frontend URL for AI chat backend calls. On Vercel deployments auto-detects `${origin}/api`; locally falls back to `http://localhost:3001`. | `http://localhost:3001` |
 | `MCP_ENABLE_RECEIPTS` | No | `0` | Set `1` to opt-in MCP local receipt storage for `stellar-search://receipts/recent` (in-memory capped at 50) | `1` |
 | `RECONCILIATION_LOG_PATH` | No | `logs/reconciliation.jsonl` | Path to the append-only settlement reconciliation log (see [Settlement reconciliation](#settlement-reconciliation)). | `/var/log/stellarsearch/reconciliation.jsonl` |
+| `SERPER_BREAKER_FAILURE_THRESHOLD` | No | `5` | Consecutive Serper failures (5xx/429/network error) required to open the circuit breaker (see [Serper circuit breaker](#serper-circuit-breaker-120)). | `5` |
+| `SERPER_BREAKER_OPEN_MS` | No | `30000` | Milliseconds the breaker stays open before allowing a half-open recovery probe. | `30000` |
+| `SERPER_BREAKER_HALF_OPEN_PROBES` | No | `1` | Concurrent requests allowed through while the breaker is half-open, testing recovery. | `1` |
 
 ---
 
@@ -143,6 +146,36 @@ Browser (Freighter) → GET /search?q=...
 To guarantee that each payment identifier authorizes **exactly one provider call**, StellarSearch tracks consumed payment identifiers across Express (`server/index.ts`) and Vercel (`api/search.ts`) runtimes:
 - **Payload Invalidation:** Extracts transaction hashes (or SHA-256 fallback hashes of payment headers) and invalidates consumed payloads for a 300-second window.
 - **Concurrency Throttling:** Rapid parallel requests using identical payment payloads are throttled so only one search query proceeds; concurrent duplicates immediately receive HTTP 402 (`Payment payload already consumed`).
+
+### Serper circuit breaker (#120)
+
+A sustained Serper.dev outage shouldn't let every incoming request hang on a
+slow/failing upstream, consuming connection slots and retry budgets while an
+agent has already committed to (or is about to commit to) a paid x402 flow.
+`src/lib/serperClient.ts` wraps every direct Serper call — in Express
+(`server/index.ts`: `/search`, `/images`, `/news`, batch JSONL, async jobs)
+and in the Vercel functions (`api/search.ts`, `api/search/batch.ts`,
+`api/jobs.ts`) — in a shared circuit breaker (`src/lib/circuitBreaker.ts`):
+
+- **Closed** (normal): requests pass through. Consecutive 5xx/429 responses
+  or network errors increment a failure counter; a single success resets it.
+- **Open**: once `SERPER_BREAKER_FAILURE_THRESHOLD` consecutive failures are
+  hit, the breaker opens. Further requests fail immediately with
+  `503 Search provider temporarily unavailable` (+ a `Retry-After` header) —
+  no network call is made — for `SERPER_BREAKER_OPEN_MS`.
+- **Half-open**: after the open duration elapses, the next
+  `SERPER_BREAKER_HALF_OPEN_PROBES` request(s) are let through as a probe. A
+  successful probe closes the breaker; a failed one re-opens it immediately.
+
+A **4xx** from Serper (e.g. a malformed query) does *not* count as a breaker
+failure — Serper answered, so that's not a signal the dependency is down.
+
+Breaker state is exposed on `GET /health` (Express) and `/api/health`
+(Vercel) as `serperCircuitBreaker: { state, failureCount, failureThreshold,
+openDurationMs, halfOpenMaxProbes, openedAt, nextAttemptAt }` for
+monitoring/alerting. The browser and MCP server never call Serper directly —
+they call these `/search`/`/images`/`/news` endpoints — so they inherit the
+fast-fail behavior transitively without their own breaker.
 
 ### Sequence diagram
 

--- a/api/health.test.ts
+++ b/api/health.test.ts
@@ -41,6 +41,10 @@ describe('api/health — Vercel health aligned with server /health', () => {
         serperApiConfigured: true,
         groqApiConfigured: true,
         receivingAddressConfigured: true,
+        serperCircuitBreaker: expect.objectContaining({
+          name: 'serper',
+          state: expect.stringMatching(/^(closed|open|half-open)$/),
+        }),
       })
     )
   })

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getSerperBreakerState } from '../src/lib/serperClient'
 import { readServerConfig } from '../src/lib/config'
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
@@ -13,6 +14,7 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
     serperApiConfigured: true,
     groqApiConfigured: !!config.groqApiKey,
     receivingAddressConfigured: true,
+    serperCircuitBreaker: getSerperBreakerState(),
     timestamp: new Date().toISOString(),
   })
 }

--- a/api/jobs.ts
+++ b/api/jobs.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { STELLAR_NETWORK, USDC_CONTRACT, AMOUNT_STROOPS, AMOUNT_USDC } from '../src/lib/constants'
 import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
 import { normalizeOrganicResults, normalizeQueryMetadata } from '../src/lib/serperNormalizer'
+import { fetchSerper } from '../src/lib/serperClient'
 import crypto from 'crypto'
 
 const RECEIVING_ADDRESS = process.env.STELLAR_RECEIVING_ADDRESS!
@@ -202,7 +203,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const dateFilters: Record<string, string> = { 'pd': 'qdr:d', 'pw': 'qdr:w', 'pm': 'qdr:m' }
         if (dateFilters[freshness]) requestBody.tbs = dateFilters[freshness]
       }
-      const serperRes = await fetch('https://google.serper.dev/search', {
+      const serperRes = await fetchSerper('/search', {
         method: 'POST',
         headers: { 'X-API-KEY': SERPER_API_KEY, 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),

--- a/api/search.ts
+++ b/api/search.ts
@@ -4,6 +4,9 @@ import {
   USDC_CONTRACT_TESTNET,
 } from '../src/lib/constants'
 import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
+import { normalizeOrganicResults, normalizeQueryMetadata } from '../src/lib/serperNormalizer'
+import { fetchSerper, CircuitOpenError } from '../src/lib/serperClient'
+import type { SearchResponse, ApiErrorResponse } from '../src/types/index.js'
 import { formatConfigurationError, readServerConfig } from '../src/lib/config'
 
 // ─── Config ───────────────────────────────────────────────────────────────
@@ -127,7 +130,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (dateFilters[freshness]) requestBody.tbs = dateFilters[freshness]
     }
 
-    const serperRes = await fetch('https://google.serper.dev/search', {
+    const serperRes = await fetchSerper('/search', {
       method:  'POST',
       headers: {
         'X-API-KEY':    SERPER_API_KEY,
@@ -167,6 +170,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.json(responseBody)
 
   } catch (err: any) {
+    if (err instanceof CircuitOpenError) {
+      console.error('[serper circuit open]', err.message)
+      res.setHeader('Retry-After', Math.ceil(err.retryAfterMs / 1000).toString())
+      const errorBody: ApiErrorResponse = { error: 'Search provider temporarily unavailable. Please retry shortly.' }
+      return res.status(503).json(errorBody)
+    }
     console.error('[search error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'Search failed.' }
     return res.status(500).json(errorBody)

--- a/api/search/batch.ts
+++ b/api/search/batch.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { STELLAR_NETWORK, USDC_CONTRACT, AMOUNT_STROOPS, AMOUNT_USDC } from '../../src/lib/constants'
 import { consumePaymentPayload } from '../../src/lib/paymentIntegrity'
 import { normalizeOrganicResults, normalizeQueryMetadata } from '../../src/lib/serperNormalizer'
+import { fetchSerper, CircuitOpenError } from '../../src/lib/serperClient'
 import crypto from 'crypto'
 
 const RECEIVING_ADDRESS = process.env.STELLAR_RECEIVING_ADDRESS!
@@ -136,7 +137,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const dateFilters: Record<string, string> = { 'pd': 'qdr:d', 'pw': 'qdr:w', 'pm': 'qdr:m' }
         if (dateFilters[freshness]) requestBody.tbs = dateFilters[freshness]
       }
-      const serperRes = await fetch('https://google.serper.dev/search', {
+      const serperRes = await fetchSerper('/search', {
         method: 'POST',
         headers: { 'X-API-KEY': SERPER_API_KEY, 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -178,6 +179,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         failed++
         for (let j = i + 1; j < cleanQueries.length; j++) { writeEvent({ v: 1, type: 'error', requestId, index: j, query: cleanQueries[j], error: 'Skipped due to abort', code: 'SKIPPED' }); failed++ }
         break
+      }
+      if (err instanceof CircuitOpenError) {
+        writeEvent({ v: 1, type: 'error', requestId, index: i, query: q, error: err.message, code: 'CIRCUIT_OPEN' })
+        failed++
+        continue
       }
       writeEvent({ v: 1, type: 'error', requestId, index: i, query: q, error: err.message || 'Search failed', code: 'SEARCH_FAILED' })
       failed++

--- a/server/health.test.ts
+++ b/server/health.test.ts
@@ -48,6 +48,15 @@ describe('GET /health and GET /', () => {
     expect(typeof res.body.serperApiConfigured).toBe('boolean')
     expect(typeof res.body.groqApiConfigured).toBe('boolean')
     expect(typeof res.body.receivingAddressConfigured).toBe('boolean')
+    // Serper circuit breaker state (issue #120)
+    expect(res.body.serperCircuitBreaker).toMatchObject({
+      name: 'serper',
+      state: expect.stringMatching(/^(closed|open|half-open)$/),
+      failureCount: expect.any(Number),
+      failureThreshold: expect.any(Number),
+      openDurationMs: expect.any(Number),
+      halfOpenMaxProbes: expect.any(Number),
+    })
   })
 
   it('GET / returns service metadata with paid routes', async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ import {
   USDC_CONTRACT
 } from '../src/lib/constants'
 import { consumePaymentPayload, extractPaymentIdentifier } from '../src/lib/paymentIntegrity'
+import { fetchSerper, CircuitOpenError, getSerperBreakerState } from '../src/lib/serperClient.js'
 import { formatConfigurationError, readServerConfig } from '../src/lib/config'
 import {
   normalizeOrganicResults,
@@ -453,7 +454,7 @@ app.get('/search', async (req: Request, res: Response) => {
       }
     }
 
-    const serperRes = await fetch('https://google.serper.dev/search', {
+    const serperRes = await fetchSerper('/search', {
       method: 'POST',
       headers: {
         'X-API-KEY': SERPER_API_KEY,
@@ -546,6 +547,12 @@ app.get('/search', async (req: Request, res: Response) => {
     resultCount = results.length
     return res.json(responseBody)
   } catch (err: any) {
+    if (err instanceof CircuitOpenError) {
+      console.error('[serper circuit open]', err.message)
+      res.setHeader('Retry-After', Math.ceil(err.retryAfterMs / 1000).toString())
+      const errorBody: ApiErrorResponse = { error: 'Search provider temporarily unavailable. Please retry shortly.' }
+      return res.status(503).json(errorBody)
+    }
     console.error('[search error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'Search failed. Check server logs.' }
     return res.status(500).json(errorBody)
@@ -573,7 +580,7 @@ app.get('/images', async (req: Request, res: Response) => {
 
     const t0 = Date.now()
 
-    const serperRes = await fetch('https://google.serper.dev/images', {
+    const serperRes = await fetchSerper('/images', {
       method: 'POST',
       headers: {
         'X-API-KEY': SERPER_API_KEY,
@@ -619,6 +626,12 @@ app.get('/images', async (req: Request, res: Response) => {
     resultCount = results.length
     return res.json(responseBody)
   } catch (err: any) {
+    if (err instanceof CircuitOpenError) {
+      console.error('[serper circuit open]', err.message)
+      res.setHeader('Retry-After', Math.ceil(err.retryAfterMs / 1000).toString())
+      const errorBody: ApiErrorResponse = { error: 'Search provider temporarily unavailable. Please retry shortly.' }
+      return res.status(503).json(errorBody)
+    }
     console.error('[images error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'Image search failed. Check server logs.' }
     return res.status(500).json(errorBody)
@@ -662,7 +675,7 @@ app.get('/news', async (req: Request, res: Response) => {
       }
     }
 
-    const serperRes = await fetch('https://google.serper.dev/news', {
+    const serperRes = await fetchSerper('/news', {
       method: 'POST',
       headers: {
         'X-API-KEY': SERPER_API_KEY,
@@ -705,6 +718,12 @@ app.get('/news', async (req: Request, res: Response) => {
     resultCount = results.length
     return res.json(responseBody)
   } catch (err: any) {
+    if (err instanceof CircuitOpenError) {
+      console.error('[serper circuit open]', err.message)
+      res.setHeader('Retry-After', Math.ceil(err.retryAfterMs / 1000).toString())
+      const errorBody: ApiErrorResponse = { error: 'Search provider temporarily unavailable. Please retry shortly.' }
+      return res.status(503).json(errorBody)
+    }
     console.error('[news error]', err.message)
     const errorBody: ApiErrorResponse = { error: 'News search failed. Check server logs.' }
     return res.status(500).json(errorBody)
@@ -833,7 +852,7 @@ app.post('/search/batch', async (req: Request, res: Response) => {
         const dateFilters: Record<string, string> = { 'pd': 'qdr:d', 'pw': 'qdr:w', 'pm': 'qdr:m' }
         if (dateFilters[freshness]) requestBody.tbs = dateFilters[freshness]
       }
-      const serperRes = await fetch('https://google.serper.dev/search', {
+      const serperRes = await fetchSerper('/search', {
         method: 'POST',
         headers: { 'X-API-KEY': SERPER_API_KEY, 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -887,6 +906,12 @@ app.post('/search/batch', async (req: Request, res: Response) => {
           writeEvent(skip); failed++
         }
         break
+      }
+      if (err instanceof CircuitOpenError) {
+        const evt: BatchJsonlErrorEvent = { v: 1, type: 'error', requestId, index: i, query: q, error: err.message, code: 'CIRCUIT_OPEN' }
+        writeEvent(evt)
+        failed++
+        continue
       }
       const evt: BatchJsonlErrorEvent = { v: 1, type: 'error', requestId, index: i, query: q, error: err.message || 'Search failed', code: 'SEARCH_FAILED' }
       writeEvent(evt)
@@ -997,7 +1022,7 @@ app.post('/jobs', async (req: Request, res: Response) => {
         const dateFilters: Record<string, string> = { 'pd': 'qdr:d', 'pw': 'qdr:w', 'pm': 'qdr:m' }
         if (dateFilters[freshness]) requestBody.tbs = dateFilters[freshness]
       }
-      const serperRes = await fetch('https://google.serper.dev/search', {
+      const serperRes = await fetchSerper('/search', {
         method: 'POST',
         headers: { 'X-API-KEY': SERPER_API_KEY, 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -1079,6 +1104,7 @@ app.get('/health', (_req: Request, res: Response) => {
     serperApiConfigured:       !!SERPER_API_KEY,
     groqApiConfigured:         !!GROQ_API_KEY,
     receivingAddressConfigured: !!RECEIVING_ADDRESS,
+    serperCircuitBreaker:      getSerperBreakerState(),
   })
 })
 

--- a/server/serperCircuitBreaker.test.ts
+++ b/server/serperCircuitBreaker.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import request from 'supertest'
+
+// Mock x402 and Groq before importing app
+vi.mock('@x402/express', () => ({
+  paymentMiddlewareFromConfig: () => (_req: any, _res: any, next: any) => next(),
+}))
+vi.mock('@x402/core/server', () => ({
+  HTTPFacilitatorClient: class { constructor(_opts: any) {} },
+}))
+vi.mock('@x402/stellar/exact/server', () => ({
+  ExactStellarScheme: class { constructor() {} },
+}))
+vi.mock('groq-sdk', () => ({
+  default: class {
+    chat = { completions: { create: vi.fn() } }
+  },
+}))
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+process.env.STELLAR_RECEIVING_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+process.env.SERPER_API_KEY = 'test-serper-key'
+process.env.GROQ_API_KEY = 'gsk_test'
+process.env.SERPER_BREAKER_FAILURE_THRESHOLD = '2'
+process.env.SERPER_BREAKER_OPEN_MS = '30000'
+process.env.SERPER_BREAKER_HALF_OPEN_PROBES = '1'
+
+let app: any
+let serperBreaker: import('../src/lib/circuitBreaker').CircuitBreaker
+
+beforeAll(async () => {
+  const mod = await import('./index.js')
+  app = mod.default
+  const client = await import('../src/lib/serperClient.js')
+  serperBreaker = client.serperBreaker
+})
+
+beforeEach(() => {
+  serperBreaker.reset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('Serper circuit breaker — server integration (issue #120)', () => {
+  it('opens after configured consecutive upstream 5xx failures and fails fast', async () => {
+    const fetchMock = vi.fn(async () => new Response('upstream down', { status: 502 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Threshold is 2 — first two calls hit the network and fail.
+    await request(app).get('/search?q=test1')
+    await request(app).get('/search?q=test2')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(serperBreaker.getSnapshot().state).toBe('open')
+
+    // Third call should fail fast without touching the network, and surface as 503.
+    const res = await request(app).get('/search?q=test3')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(res.status).toBe(503)
+    expect(res.body.error).toMatch(/temporarily unavailable/i)
+    expect(res.headers['retry-after']).toBeDefined()
+  })
+
+  it('recovers via a half-open probe once openDurationMs elapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('down', { status: 502 }))
+      .mockResolvedValueOnce(new Response('down', { status: 502 }))
+      .mockResolvedValue(
+        new Response(JSON.stringify({ organic: [{ title: 'ok', link: 'https://example.com', snippet: 's' }] }), { status: 200 })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await request(app).get('/search?q=test1')
+    await request(app).get('/search?q=test2')
+    expect(serperBreaker.getSnapshot().state).toBe('open')
+
+    vi.advanceTimersByTime(30_000)
+    expect(serperBreaker.getSnapshot().state).toBe('half-open')
+
+    const res = await request(app).get('/search?q=test3')
+    expect(res.status).toBe(200)
+    expect(serperBreaker.getSnapshot().state).toBe('closed')
+  })
+
+  it('does not trip the breaker on a 4xx (bad request) response from Serper', async () => {
+    const fetchMock = vi.fn(async () => new Response('bad request', { status: 400 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await request(app).get('/search?q=test1')
+    await request(app).get('/search?q=test2')
+    await request(app).get('/search?q=test3')
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(serperBreaker.getSnapshot().state).toBe('closed')
+  })
+})

--- a/src/lib/circuitBreaker.test.ts
+++ b/src/lib/circuitBreaker.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { CircuitBreaker, CircuitOpenError } from './circuitBreaker'
+
+describe('CircuitBreaker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stays closed and passes calls through while under the failure threshold', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 3, openDurationMs: 1000 })
+
+    await expect(breaker.execute(async () => 'ok')).resolves.toBe('ok')
+    await expect(breaker.execute(async () => { throw new Error('boom') })).rejects.toThrow('boom')
+    await expect(breaker.execute(async () => { throw new Error('boom') })).rejects.toThrow('boom')
+
+    expect(breaker.getSnapshot().state).toBe('closed')
+    expect(breaker.getSnapshot().failureCount).toBe(2)
+  })
+
+  it('trips open after `failureThreshold` consecutive failures and fails fast', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 2, openDurationMs: 5000 })
+
+    await expect(breaker.execute(async () => { throw new Error('e1') })).rejects.toThrow('e1')
+    await expect(breaker.execute(async () => { throw new Error('e2') })).rejects.toThrow('e2')
+
+    expect(breaker.getSnapshot().state).toBe('open')
+
+    const fn = vi.fn(async () => 'should not run')
+    await expect(breaker.execute(fn)).rejects.toBeInstanceOf(CircuitOpenError)
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('a single success resets the consecutive failure counter', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 3, openDurationMs: 1000 })
+
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+    await expect(breaker.execute(async () => 'ok')).resolves.toBe('ok')
+
+    expect(breaker.getSnapshot().failureCount).toBe(0)
+    expect(breaker.getSnapshot().state).toBe('closed')
+  })
+
+  it('uses the isFailure classifier to count resolved-but-bad results as failures', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 1000 })
+
+    await breaker.execute(async () => ({ status: 500 }), (r) => r.status >= 500)
+
+    expect(breaker.getSnapshot().state).toBe('open')
+  })
+
+  it('does not count a resolved result as a failure unless isFailure says so', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 1000 })
+
+    await breaker.execute(async () => ({ status: 404 }), (r) => r.status >= 500)
+
+    expect(breaker.getSnapshot().state).toBe('closed')
+  })
+
+  it('moves to half-open after openDurationMs and allows a bounded probe through', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 10_000, halfOpenMaxProbes: 1 })
+
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+    expect(breaker.getSnapshot().state).toBe('open')
+
+    vi.advanceTimersByTime(9_999)
+    expect(breaker.getSnapshot().state).toBe('open')
+
+    vi.advanceTimersByTime(1)
+    expect(breaker.getSnapshot().state).toBe('half-open')
+
+    await expect(breaker.execute(async () => 'recovered')).resolves.toBe('recovered')
+    expect(breaker.getSnapshot().state).toBe('closed')
+  })
+
+  it('re-opens immediately if the half-open probe fails', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 5000 })
+
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+    vi.advanceTimersByTime(5000)
+    expect(breaker.getSnapshot().state).toBe('half-open')
+
+    await expect(breaker.execute(async () => { throw new Error('still down') })).rejects.toThrow('still down')
+    expect(breaker.getSnapshot().state).toBe('open')
+  })
+
+  it('limits concurrent half-open probes to halfOpenMaxProbes', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 5000, halfOpenMaxProbes: 1 })
+
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+    vi.advanceTimersByTime(5000)
+    expect(breaker.getSnapshot().state).toBe('half-open')
+
+    let releaseFirst: () => void = () => {}
+    const gate = new Promise<void>((resolve) => { releaseFirst = resolve })
+    const firstProbe = breaker.execute(async () => { await gate; return 'first' })
+
+    // A second call while the first probe is still in flight should be rejected fast.
+    await expect(breaker.execute(async () => 'second')).rejects.toBeInstanceOf(CircuitOpenError)
+
+    releaseFirst()
+    await expect(firstProbe).resolves.toBe('first')
+  })
+
+  it('exposes retryAfterMs on CircuitOpenError reflecting remaining open time', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 10_000 })
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+
+    vi.advanceTimersByTime(4000)
+    try {
+      await breaker.execute(async () => 'x')
+      expect.unreachable()
+    } catch (err) {
+      expect(err).toBeInstanceOf(CircuitOpenError)
+      expect((err as CircuitOpenError).retryAfterMs).toBe(6000)
+    }
+  })
+
+  it('reset() forces the breaker back to closed', async () => {
+    const breaker = new CircuitBreaker({ name: 'test', failureThreshold: 1, openDurationMs: 10_000 })
+    await expect(breaker.execute(async () => { throw new Error('e') })).rejects.toThrow()
+    expect(breaker.getSnapshot().state).toBe('open')
+
+    breaker.reset()
+    expect(breaker.getSnapshot()).toMatchObject({ state: 'closed', failureCount: 0, openedAt: null })
+  })
+
+  it('getSnapshot exposes configured thresholds for health/metrics endpoints', () => {
+    const breaker = new CircuitBreaker({ name: 'serper', failureThreshold: 5, openDurationMs: 30_000, halfOpenMaxProbes: 2 })
+    const snap = breaker.getSnapshot()
+    expect(snap).toMatchObject({
+      name: 'serper',
+      state: 'closed',
+      failureThreshold: 5,
+      openDurationMs: 30_000,
+      halfOpenMaxProbes: 2,
+    })
+  })
+})

--- a/src/lib/circuitBreaker.ts
+++ b/src/lib/circuitBreaker.ts
@@ -1,0 +1,169 @@
+/**
+ * Generic circuit breaker.
+ *
+ * Wraps calls to a flaky/slow dependency so that once it starts failing
+ * consistently, further calls fail fast (no network round trip, no
+ * connection/retry-budget consumption) instead of piling up behind a
+ * dependency that isn't going to answer. After `openDurationMs` it lets a
+ * bounded number of "probe" calls through to test recovery before fully
+ * closing again.
+ *
+ * States:
+ *   closed    → calls pass through; consecutive failures are counted
+ *   open      → calls are rejected immediately with CircuitOpenError
+ *   half-open → up to `halfOpenMaxProbes` calls are allowed through; a
+ *               single failure re-opens the circuit, a success closes it
+ */
+
+export type CircuitState = 'closed' | 'open' | 'half-open'
+
+export interface CircuitBreakerOptions {
+  /** Label used in error messages / metrics. */
+  name?: string
+  /** Consecutive failures required to trip the breaker open. */
+  failureThreshold: number
+  /** How long the breaker stays open before allowing a half-open probe. */
+  openDurationMs: number
+  /** Concurrent calls allowed through while half-open. Defaults to 1. */
+  halfOpenMaxProbes?: number
+}
+
+export interface CircuitBreakerSnapshot {
+  name: string
+  state: CircuitState
+  failureCount: number
+  failureThreshold: number
+  openDurationMs: number
+  halfOpenMaxProbes: number
+  openedAt: number | null
+  /** epoch ms when the breaker will next allow a half-open probe, or null if not open. */
+  nextAttemptAt: number | null
+}
+
+export class CircuitOpenError extends Error {
+  constructor(
+    public readonly circuitName: string,
+    public readonly retryAfterMs: number
+  ) {
+    super(`Circuit breaker "${circuitName}" is open — failing fast (retry in ${retryAfterMs}ms)`)
+    this.name = 'CircuitOpenError'
+  }
+}
+
+export class CircuitBreaker {
+  private state: CircuitState = 'closed'
+  private failureCount = 0
+  private openedAt: number | null = null
+  private halfOpenProbesInFlight = 0
+
+  private readonly name: string
+  private readonly failureThreshold: number
+  private readonly openDurationMs: number
+  private readonly halfOpenMaxProbes: number
+
+  constructor(options: CircuitBreakerOptions) {
+    this.name = options.name ?? 'circuit'
+    this.failureThreshold = options.failureThreshold
+    this.openDurationMs = options.openDurationMs
+    this.halfOpenMaxProbes = options.halfOpenMaxProbes ?? 1
+  }
+
+  /** Current state + counters, for health/metrics endpoints. Advances open → half-open as a side effect if the open duration has elapsed. */
+  getSnapshot(): CircuitBreakerSnapshot {
+    this.maybeEnterHalfOpen()
+    return {
+      name: this.name,
+      state: this.state,
+      failureCount: this.failureCount,
+      failureThreshold: this.failureThreshold,
+      openDurationMs: this.openDurationMs,
+      halfOpenMaxProbes: this.halfOpenMaxProbes,
+      openedAt: this.openedAt,
+      nextAttemptAt: this.openedAt !== null ? this.openedAt + this.openDurationMs : null,
+    }
+  }
+
+  private maybeEnterHalfOpen(): void {
+    if (
+      this.state === 'open' &&
+      this.openedAt !== null &&
+      Date.now() - this.openedAt >= this.openDurationMs
+    ) {
+      this.state = 'half-open'
+      this.halfOpenProbesInFlight = 0
+    }
+  }
+
+  private retryAfterMs(): number {
+    if (this.openedAt === null) return this.openDurationMs
+    return Math.max(0, this.openedAt + this.openDurationMs - Date.now())
+  }
+
+  /**
+   * Runs `fn` if the circuit allows it, otherwise throws CircuitOpenError
+   * without calling `fn` at all. `isFailure` classifies a *resolved* value
+   * as a failure worth counting (e.g. an HTTP 500 Response) — a thrown
+   * error/rejected promise always counts as a failure regardless.
+   */
+  async execute<T>(fn: () => Promise<T>, isFailure: (result: T) => boolean = () => false): Promise<T> {
+    this.maybeEnterHalfOpen()
+
+    if (this.state === 'open') {
+      throw new CircuitOpenError(this.name, this.retryAfterMs())
+    }
+
+    const isProbe = this.state === 'half-open'
+    if (isProbe) {
+      if (this.halfOpenProbesInFlight >= this.halfOpenMaxProbes) {
+        throw new CircuitOpenError(this.name, this.retryAfterMs())
+      }
+      this.halfOpenProbesInFlight++
+    }
+
+    try {
+      const result = await fn()
+      if (isFailure(result)) {
+        this.onFailure()
+      } else {
+        this.onSuccess()
+      }
+      return result
+    } catch (err) {
+      this.onFailure()
+      throw err
+    } finally {
+      if (isProbe) this.halfOpenProbesInFlight = Math.max(0, this.halfOpenProbesInFlight - 1)
+    }
+  }
+
+  private onSuccess(): void {
+    this.failureCount = 0
+    this.state = 'closed'
+    this.openedAt = null
+  }
+
+  private onFailure(): void {
+    if (this.state === 'half-open') {
+      this.trip()
+      return
+    }
+    this.failureCount++
+    if (this.failureCount >= this.failureThreshold) {
+      this.trip()
+    }
+  }
+
+  private trip(): void {
+    this.state = 'open'
+    this.openedAt = Date.now()
+    this.halfOpenProbesInFlight = 0
+  }
+
+  /** Forces the breaker back to a clean closed state. Mainly for tests. */
+  reset(): void {
+    this.state = 'closed'
+    this.failureCount = 0
+    this.openedAt = null
+    this.halfOpenProbesInFlight = 0
+  }
+}

--- a/src/lib/serperClient.test.ts
+++ b/src/lib/serperClient.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('serperClient', () => {
+  const originalEnv = { ...process.env }
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('reads breaker thresholds from env vars', async () => {
+    process.env.SERPER_BREAKER_FAILURE_THRESHOLD = '2'
+    process.env.SERPER_BREAKER_OPEN_MS = '5000'
+    process.env.SERPER_BREAKER_HALF_OPEN_PROBES = '3'
+
+    const { getSerperBreakerState } = await import('./serperClient')
+    const snap = getSerperBreakerState()
+    expect(snap.failureThreshold).toBe(2)
+    expect(snap.openDurationMs).toBe(5000)
+    expect(snap.halfOpenMaxProbes).toBe(3)
+  })
+
+  it('falls back to defaults for invalid/missing env vars', async () => {
+    delete process.env.SERPER_BREAKER_FAILURE_THRESHOLD
+    process.env.SERPER_BREAKER_OPEN_MS = 'not-a-number'
+
+    const { getSerperBreakerState } = await import('./serperClient')
+    const snap = getSerperBreakerState()
+    expect(snap.failureThreshold).toBe(5)
+    expect(snap.openDurationMs).toBe(30_000)
+  })
+
+  it('fetchSerper calls the real Serper base URL with the given path', async () => {
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+    global.fetch = fetchMock as any
+
+    const { fetchSerper } = await import('./serperClient')
+    await fetchSerper('/search', { method: 'POST', headers: { 'X-API-KEY': 'k' } })
+
+    expect(fetchMock).toHaveBeenCalledWith('https://google.serper.dev/search', { method: 'POST', headers: { 'X-API-KEY': 'k' } })
+  })
+
+  it('trips the breaker on repeated 5xx responses and then fails fast without calling fetch', async () => {
+    process.env.SERPER_BREAKER_FAILURE_THRESHOLD = '2'
+    const fetchMock = vi.fn(async () => new Response('boom', { status: 502 }))
+    global.fetch = fetchMock as any
+
+    const { fetchSerper, CircuitOpenError } = await import('./serperClient')
+
+    await fetchSerper('/search', {})
+    await fetchSerper('/search', {})
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await expect(fetchSerper('/search', {})).rejects.toBeInstanceOf(CircuitOpenError)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not trip the breaker on a 4xx (client-error) response', async () => {
+    process.env.SERPER_BREAKER_FAILURE_THRESHOLD = '1'
+    const fetchMock = vi.fn(async () => new Response('bad request', { status: 400 }))
+    global.fetch = fetchMock as any
+
+    const { fetchSerper, getSerperBreakerState } = await import('./serperClient')
+    const res = await fetchSerper('/search', {})
+
+    expect(res.status).toBe(400)
+    expect(getSerperBreakerState().state).toBe('closed')
+  })
+
+  it('trips the breaker on a 429', async () => {
+    process.env.SERPER_BREAKER_FAILURE_THRESHOLD = '1'
+    const fetchMock = vi.fn(async () => new Response('rate limited', { status: 429 }))
+    global.fetch = fetchMock as any
+
+    const { fetchSerper, getSerperBreakerState } = await import('./serperClient')
+    await fetchSerper('/search', {})
+
+    expect(getSerperBreakerState().state).toBe('open')
+  })
+
+  it('a network-level throw counts as a failure', async () => {
+    process.env.SERPER_BREAKER_FAILURE_THRESHOLD = '1'
+    const fetchMock = vi.fn(async () => { throw new Error('network down') })
+    global.fetch = fetchMock as any
+
+    const { fetchSerper, getSerperBreakerState } = await import('./serperClient')
+    await expect(fetchSerper('/search', {})).rejects.toThrow('network down')
+
+    expect(getSerperBreakerState().state).toBe('open')
+  })
+})

--- a/src/lib/serperClient.ts
+++ b/src/lib/serperClient.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared Serper.dev HTTP client, wrapped in a circuit breaker.
+ *
+ * Used by every runtime that calls Serper directly (Express `server/index.ts`
+ * and the Vercel functions under `api/`). The browser and MCP server never
+ * call Serper directly — they call these runtimes' `/search`, `/images`,
+ * `/news` endpoints — so protecting the two direct callers protects every
+ * surface transitively.
+ *
+ * A response is only counted as a breaker failure for 5xx / 429 (transient
+ * upstream trouble) — a 4xx from a malformed request still means Serper
+ * answered, so it doesn't indicate the dependency is unhealthy.
+ */
+import { CircuitBreaker, CircuitOpenError, type CircuitBreakerSnapshot } from './circuitBreaker'
+
+const SERPER_BASE_URL = 'https://google.serper.dev'
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const n = parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+export const serperBreaker = new CircuitBreaker({
+  name: 'serper',
+  failureThreshold: envInt('SERPER_BREAKER_FAILURE_THRESHOLD', 5),
+  openDurationMs: envInt('SERPER_BREAKER_OPEN_MS', 30_000),
+  halfOpenMaxProbes: envInt('SERPER_BREAKER_HALF_OPEN_PROBES', 1),
+})
+
+export { CircuitOpenError }
+export type { CircuitBreakerSnapshot }
+
+export function getSerperBreakerState(): CircuitBreakerSnapshot {
+  return serperBreaker.getSnapshot()
+}
+
+function isUpstreamFailure(res: Response): boolean {
+  return res.status >= 500 || res.status === 429
+}
+
+/**
+ * Drop-in replacement for `fetch(\`https://google.serper.dev${path}\`, init)`
+ * that fails fast with CircuitOpenError instead of hitting the network once
+ * the breaker is open. Non-2xx responses that *do* come back are still
+ * returned normally (callers keep their existing status-code handling) —
+ * only the breaker's internal accounting is affected.
+ */
+export async function fetchSerper(path: string, init: RequestInit): Promise<Response> {
+  return serperBreaker.execute(() => fetch(`${SERPER_BASE_URL}${path}`, init), isUpstreamFailure)
+}


### PR DESCRIPTION
## Summary

Fixes #120 — sustained Serper.dev failures previously meant every incoming request kept hitting the failing upstream directly, consuming connection slots, retry budgets, and (worse) letting a caller commit to — or already be mid — an x402 payment flow for a query that was always going to fail.

**Design:**
- `src/lib/circuitBreaker.ts` — a generic, dependency-free `CircuitBreaker` with **configurable** failure threshold, open duration, and half-open probe count (per the acceptance criteria). Standard closed → open → half-open state machine:
  - **Closed:** calls pass through; consecutive failures increment a counter, a single success resets it.
  - **Open:** once the threshold is hit, calls are rejected immediately with `CircuitOpenError` (no network call) until the open duration elapses.
  - **Half-open:** a bounded number of probe calls are let through to test recovery; success closes the breaker, failure re-opens it immediately.
- `src/lib/serperClient.ts` — a shared `fetchSerper()` wrapping every direct Serper call in one breaker instance, configured from env vars (`SERPER_BREAKER_FAILURE_THRESHOLD`, `SERPER_BREAKER_OPEN_MS`, `SERPER_BREAKER_HALF_OPEN_PROBES`, sensible defaults 5 / 30000 / 1). A response only counts as a breaker failure on 5xx or 429 — a 4xx means Serper answered, so it isn't treated as a health signal.
- Wired into **every** direct Serper call site so behavior stays aligned across runtimes: Express (`server/index.ts`: `/search`, `/images`, `/news`, batch JSONL, async jobs) and Vercel (`api/search.ts`, `api/search/batch.ts`, `api/jobs.ts`). The browser and MCP server never call Serper directly — they call these endpoints — so they inherit the fast-fail behavior transitively without needing their own breaker.
- When the breaker is open, the paid search endpoints now return `503` with a clear message and a `Retry-After` header instead of a generic `500`/`502`, and streaming/batch consumers get a `CIRCUIT_OPEN` event code instead of a hang.

**Observability:** breaker state (`state`, `failureCount`, `failureThreshold`, `openDurationMs`, `halfOpenMaxProbes`, `openedAt`, `nextAttemptAt`) is exposed as `serperCircuitBreaker` on `GET /health` (Express) and `/api/health` (Vercel), satisfying the "health/metrics expose breaker state" acceptance criterion.

## Changes
- `src/lib/circuitBreaker.ts` (new) — generic circuit breaker
- `src/lib/serperClient.ts` (new) — Serper-specific breaker-wrapped fetch
- `server/index.ts` — all 5 direct Serper call sites routed through `fetchSerper`; `/health` exposes breaker state; `CircuitOpenError` mapped to `503`/`Retry-After` (or `CIRCUIT_OPEN` event code for the batch/streaming path)
- `api/search.ts`, `api/search/batch.ts`, `api/jobs.ts` — same treatment for the Vercel runtime
- `api/health.ts` — exposes breaker state
- `src/lib/circuitBreaker.test.ts`, `src/lib/serperClient.test.ts` (new) — unit tests using **fake timers** for the closed→open→half-open→closed lifecycle, threshold configurability, 4xx-doesn't-trip / 429-does-trip classification, and bounded half-open concurrency
- `server/serperCircuitBreaker.test.ts` (new) — integration test hitting `/search` through Express: opens after N failures and fails fast without touching the network, recovers via a half-open probe (fake timers), and confirms 4xx doesn't trip it
- `server/health.test.ts`, `api/health.test.ts` — assert `serperCircuitBreaker` is present in the health payload
- `README.md` — documents the breaker's behavior and the new env vars

## Test plan
- [x] `npx vitest run src/lib/circuitBreaker.test.ts src/lib/serperClient.test.ts` — 18/18 pass
- [x] `npx vitest run server/serperCircuitBreaker.test.ts server/health.test.ts api/health.test.ts` — all pass
- [x] Full `npx vitest run` — no regressions (the one failing test, `mcp-server/tools.test.ts`, fails identically on `main` before this change — an unrelated pre-existing mock-setup issue)
- [x] `npm run typecheck:frontend` / `typecheck:server` — clean (pre-existing `typecheck:api`/`typecheck:mcp` errors on `main` are unrelated path/const issues, unaffected by this change)
- [x] `npx eslint` on all touched files — no new lint errors (pre-existing `no-empty`/`no-useless-assignment` findings in `server/index.ts`/`api/jobs.ts`/`api/search/batch.ts` predate this change)