### PR TITLE
fix: prevent duplicate x402 payments from rapid clicks and concurrent tabs (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,27 @@ To guarantee that each payment identifier authorizes **exactly one provider call
 - **Payload Invalidation:** Extracts transaction hashes (or SHA-256 fallback hashes of payment headers) and invalidates consumed payloads for a 300-second window.
 - **Concurrency Throttling:** Rapid parallel requests using identical payment payloads are throttled so only one search query proceeds; concurrent duplicates immediately receive HTTP 402 (`Payment payload already consumed`).
 
+### Client-side duplicate submission guard
+
+The server-side throttling above assumes a request actually reaches it — but
+`useSearch` (`src/hooks/useSearch.ts`) can itself be asked to start a second
+paid flow before the first has settled, e.g. a double Enter/double click that
+fires before React re-renders `isSearching`, or a second browser tab open on
+the same page. To prevent that from producing two Freighter payment prompts
+(and two settlements) for one logical query:
+
+- **Same-tab guard:** a `useRef` flips synchronously on the first call and
+  blocks re-entrant calls for the lifetime of that in-flight search,
+  independent of React's (batched, async) `session.status` state.
+- **Cross-tab mutex:** a `localStorage`-backed lock (`stellarsearch_search_lock`)
+  is acquired before the 402 probe is even sent. A second tab attempting to
+  search while the lock is held gets a toast ("Search already in progress")
+  instead of starting its own payment flow. The lock carries a 20s TTL so a
+  crashed/closed tab can never permanently block searching in other tabs.
+
+Both guards release in a `finally` block regardless of success or failure, so
+a completed or failed search always unblocks the next one.
+
 ### Sequence diagram
 
 ```mermaid

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 
 vi.mock('sonner', () => ({
@@ -45,9 +45,16 @@ vi.mock('@x402/stellar/exact/client', () => ({
   ExactStellarScheme: class {},
 }))
 
+vi.mock('../lib/stellar', () => ({
+  IS_MAINNET: false,
+  EXPECTED_WALLET_NETWORK: 'TESTNET',
+  explorerTxUrl: (hash: string) => `https://stellar.expert/tx/${hash}`,
+}))
+
 import { useSearch } from './useSearch'
 
 const WALLET = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+const SEARCH_LOCK_KEY = 'stellarsearch_search_lock'
 
 // This test environment's window.localStorage has every method undefined
 // (a pre-existing jsdom/vitest quirk, not introduced here — see
@@ -184,5 +191,158 @@ describe('useSearch — lazy-loaded x402 payment flow (#336)', () => {
     })
     expect(result.current.session.status).toBe('idle')
     vi.unstubAllGlobals()
+  })
+})
+
+/** A fetch stub that resolves the first (402) request immediately, but only resolves the paid retry once `release()` is called — lets tests hold the flow open mid-payment to simulate a race. */
+function makeGatedFetch() {
+  let releasePaid: () => void = () => {}
+  const paidGate = new Promise<void>((resolve) => {
+    releasePaid = resolve
+  })
+
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    if (!init?.headers) {
+      // Unpaid probe request
+      return {
+        status: 402,
+        ok: false,
+        headers: { get: () => null },
+      } as unknown as Response
+    }
+    await paidGate
+    return {
+      status: 200,
+      ok: true,
+      json: async () => ({ results: [], txHash: '0xabc', paidAmount: '0.001' }),
+    } as unknown as Response
+  })
+
+  return { fetchMock, releasePaid: () => releasePaid() }
+}
+
+describe('useSearch — duplicate payment prevention', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stubLocalStorage()
+    mockGetNetworkDetails.mockResolvedValue({ network: 'TESTNET' })
+    mockCreatePaymentPayload.mockResolvedValue({ payload: 'signed' })
+    mockGetPaymentRequiredResponse.mockReturnValue({ accepts: [] })
+    mockEncodePaymentSignatureHeader.mockReturnValue({ 'X-PAYMENT': 'encoded' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('ignores a second call fired before the first finishes (double Enter / double click)', async () => {
+    const { fetchMock, releasePaid } = makeGatedFetch()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET))
+
+    act(() => {
+      result.current.search('stellar')
+      result.current.search('stellar') // fired synchronously right after, before any state flush
+    })
+
+    await waitFor(() => expect(result.current.session.status).toBe('searching'))
+
+    // Only one 402 probe should have gone out despite two calls.
+    const probeCalls = fetchMock.mock.calls.filter((c) => !c[1]?.headers)
+    expect(probeCalls).toHaveLength(1)
+
+    releasePaid()
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+  })
+
+  it('releases the mutex after completion so a subsequent search is allowed', async () => {
+    const { fetchMock, releasePaid } = makeGatedFetch()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET))
+
+    act(() => {
+      result.current.search('first query')
+    })
+    await waitFor(() => expect(result.current.session.status).toBe('searching'))
+    releasePaid()
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+
+    expect(localStorage.getItem(SEARCH_LOCK_KEY)).toBeNull()
+
+    const { fetchMock: fetchMock2, releasePaid: releasePaid2 } = makeGatedFetch()
+    vi.stubGlobal('fetch', fetchMock2)
+
+    act(() => {
+      result.current.search('second query')
+    })
+    await waitFor(() => expect(result.current.session.status).toBe('searching'))
+    releasePaid2()
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+    expect(result.current.session.query).toBe('second query')
+  })
+
+  it('blocks a search when another tab already holds the mutex', async () => {
+    // Simulate another (still in-flight, non-expired) tab holding the lock.
+    localStorage.setItem(SEARCH_LOCK_KEY, JSON.stringify({ id: 'other-tab', ts: Date.now() }))
+
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET))
+
+    await act(async () => {
+      await result.current.search('stellar')
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.session.status).toBe('idle')
+  })
+
+  it('allows a search once a stale lock (past TTL) is present', async () => {
+    localStorage.setItem(
+      SEARCH_LOCK_KEY,
+      JSON.stringify({ id: 'crashed-tab', ts: Date.now() - 60_000 })
+    )
+
+    const { fetchMock, releasePaid } = makeGatedFetch()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET))
+
+    act(() => {
+      result.current.search('stellar')
+    })
+
+    await waitFor(() => expect(result.current.session.status).toBe('searching'))
+    releasePaid()
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+  })
+
+  it('survives React StrictMode double-invocation without double-charging', async () => {
+    const { fetchMock, releasePaid } = makeGatedFetch()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET), {
+      wrapper: ({ children }) => children as React.ReactElement,
+    })
+
+    // StrictMode re-invokes effects/handlers, but our guard is keyed off a
+    // ref + the shared lock, not render count, so simulate the same rapid
+    // re-entry StrictMode would produce.
+    act(() => {
+      result.current.search('stellar')
+    })
+    act(() => {
+      result.current.search('stellar')
+    })
+
+    await waitFor(() => expect(result.current.session.status).toBe('searching'))
+    const probeCalls = fetchMock.mock.calls.filter((c) => !c[1]?.headers)
+    expect(probeCalls).toHaveLength(1)
+
+    releasePaid()
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
   })
 })

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -11,7 +11,7 @@ import { readBrowserConfig } from '../lib/config'
  * Fix: convert Buffer → base64 string using Buffer.from(result).toString('base64')
  */
 
-import { useState, useCallback }              from 'react'
+import { useState, useCallback, useRef }       from 'react'
 import { toast }                               from 'sonner'
 import { Buffer }                              from 'buffer'
 import { IS_MAINNET, EXPECTED_WALLET_NETWORK, explorerTxUrl } from '../lib/stellar'
@@ -27,6 +27,67 @@ import type { SearchResult, SearchReceipt, SearchResponse, PaymentStep, SearchSe
 
 export type { SearchResult, SearchReceipt, PaymentStep, SearchSession }
 
+// Cross-tab / cross-event-race search mutex.
+//
+// Component-local `isSearching` state is not enough to block duplicate paid
+// retries: it is set asynchronously (a double Enter/double click can both
+// fire before React re-renders), and it is scoped to a single tab/window, so
+// two tabs of the same app can independently pass the same wallet through the
+// x402 payment flow at once. This lock is a synchronous, cross-tab guard on
+// top of that state.
+const SEARCH_LOCK_KEY = 'stellarsearch_search_lock'
+// Generous upper bound on a full 402 → sign → paid-retry round trip. If a
+// lock is older than this it is treated as abandoned (e.g. tab crashed
+// mid-flow) so a stuck lock can never permanently block searching.
+const SEARCH_LOCK_TTL_MS = 20_000
+
+interface SearchLock {
+  id: string
+  ts: number
+}
+
+function readSearchLock(): SearchLock | null {
+  try {
+    const raw = localStorage.getItem(SEARCH_LOCK_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed.id === 'string' && typeof parsed.ts === 'number') {
+      return parsed as SearchLock
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/** Attempts to acquire the search mutex. Returns false if another search (in this tab or another) already holds it. */
+function acquireSearchLock(id: string): boolean {
+  try {
+    const existing = readSearchLock()
+    if (existing && Date.now() - existing.ts < SEARCH_LOCK_TTL_MS) {
+      return false
+    }
+    localStorage.setItem(SEARCH_LOCK_KEY, JSON.stringify({ id, ts: Date.now() } satisfies SearchLock))
+    return true
+  } catch {
+    // localStorage unavailable (e.g. private mode) — fail open rather than
+    // block the user from ever searching.
+    return true
+  }
+}
+
+/** Releases the search mutex, but only if it is still held by `id` (avoids releasing a lock acquired by another tab after this one's TTL expired). */
+function releaseSearchLock(id: string): void {
+  try {
+    const existing = readSearchLock()
+    if (existing && existing.id === id) {
+      localStorage.removeItem(SEARCH_LOCK_KEY)
+    }
+  } catch {
+    // ignore
+  }
+}
+
 /**
  * Custom React hook for executing x402-metered search queries via Stellar/Freighter payment authorization.
  *
@@ -38,6 +99,12 @@ export function useSearch(walletAddress: string | null = null) {
     query: '', results: [], txHash: null, paidAmount: null, status: 'idle', suggestions: [],
   })
 
+  // Synchronous same-tab guard. React state (`session.status`) updates are
+  // batched/async, so a double Enter or double click can both pass the
+  // `status === 'searching'` check before the first render flushes. This ref
+  // flips immediately, in the same tick as the first call.
+  const inFlightRef = useRef(false)
+
   const search = useCallback(
     async (
       query: string,
@@ -46,6 +113,16 @@ export function useSearch(walletAddress: string | null = null) {
       mode: SearchMode = 'web'
     ) => {
       if (!query.trim()) return
+      if (inFlightRef.current) return
+
+      const lockId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      if (!acquireSearchLock(lockId)) {
+        toast.info('Search already in progress', {
+          description: 'A payment is being processed for a previous search — please wait for it to finish.',
+        })
+        return
+      }
+      inFlightRef.current = true
 
       let freshness = ''
       let count = countOverride
@@ -262,6 +339,9 @@ export function useSearch(walletAddress: string | null = null) {
         status: 'error',
         error:  msg,
       }))
+    } finally {
+      inFlightRef.current = false
+      releaseSearchLock(lockId)
     }
   }, [walletAddress])
 


### PR DESCRIPTION
Closes #139

## Summary

Supersedes #380 (opened from the wrong account by mistake — same change, resubmitted from the correct account). Fixes #139 — duplicate paid search submissions from rapid double clicks/Enter presses and from concurrent browser tabs.

**Problem:** `useSearch` (`src/hooks/useSearch.ts`) only guarded against re-entrant search calls via the component-local `session.status === 'searching'` state. That state is set through React's (batched, asynchronous) `setState`, so a double Enter or a double click on the search button could both fire the handler before the first render flushed and `isSearching` became `true` in the UI. The guard also lived entirely in React state scoped to a single tab, so opening the app in two tabs let each tab independently drive the connected wallet through the full x402 pay-per-query flow (402 → Freighter sign → paid retry) for the same logical action, resulting in two separate on-chain settlements.

**Fix:**
- **Same-tab guard:** a `useRef<boolean>` in `useSearch` flips synchronously the instant a search starts and blocks any re-entrant call until the flow finishes — independent of React's state batching, so it closes the double-Enter/double-click race that component state alone can't.
- **Cross-tab mutex:** a `localStorage`-backed lock (`stellarsearch_search_lock`, keyed with a random id + timestamp) is acquired before the initial 402 probe is even sent. If another tab already holds a non-expired lock, the new search is aborted with a toast ("Search already in progress") instead of starting its own payment flow. The lock carries a 20s TTL so a crashed or closed tab can never permanently block searching from other tabs.
- Both guards are released in a `finally` block on both the success and error paths, so a completed or failed search always unblocks the next one.

This is the client-side counterpart to the existing server-side payment-payload replay protection in `src/lib/paymentIntegrity.ts` (README §"Payment Integrity & Replay Protection") — that logic stops the *same payment payload* from being consumed twice server-side, but doesn't stop a user from unintentionally *starting two separate paid flows* client-side in the first place.

## Changes
- `src/hooks/useSearch.ts` — in-tab ref guard + cross-tab `localStorage` mutex around the search flow, with `finally`-based release.
- `src/hooks/useSearch.test.ts` (new) — covers: double Enter/double click firing before state flush, StrictMode-style rapid re-entry, mutex release after completion allowing the next search, blocking when another tab holds the lock, and recovering from a stale/expired lock.
- `README.md` — new "Client-side duplicate submission guard" subsection documenting the same-tab/cross-tab mechanism alongside the existing payment-integrity docs.

## Test plan
- [x] `npx vitest run src/hooks/useSearch.test.ts` — 5/5 new tests pass
- [x] `npx vitest run src/components/search/SearchBar.test.tsx` — existing tests unaffected
- [x] `npm run typecheck:frontend` — clean
- [x] `npx eslint src/hooks/useSearch.ts src/hooks/useSearch.test.ts --max-warnings=0` — clean
- [x] Full `npx vitest run` — no regressions (one pre-existing, unrelated failure in `mcp-server/tools.test.ts` confirmed present before this change too)