### PR TITLE
Lazy-load Stellar wallet SDKs only when wallet features are used

### DIFF
--- a/src/hooks/useFreighterWallet.ts
+++ b/src/hooks/useFreighterWallet.ts
@@ -5,19 +5,40 @@
  */
 
 import { useState, useCallback, useEffect } from 'react'
-import {
-  isConnected,
-  requestAccess,
-  getAddress,
-  getNetwork,
-} from '@stellar/freighter-api'
-import { Horizon } from '@stellar/stellar-sdk'
 import { HORIZON_URL, USDC_ISSUER } from '../lib/stellar'
 import type { WalletState, StellarTransaction } from '../types'
 
 export type { WalletState, StellarTransaction }
 
-const horizon = new Horizon.Server(HORIZON_URL)
+// `@stellar/freighter-api` and `@stellar/stellar-sdk` are loaded on demand
+// rather than imported statically — every page (docs, a still-disconnected
+// search) previously pulled both into the main bundle just by mounting this
+// hook, even though neither is needed until the wallet is actually connected
+// (or, for Horizon, until a connected wallet's balances/history are fetched)
+// (#336). Each loader is memoized so repeated calls (e.g. connect() followed
+// by refresh()) reuse the same module/instance instead of re-importing.
+
+type FreighterApi = typeof import('@stellar/freighter-api')
+let freighterApiPromise: Promise<FreighterApi> | null = null
+function loadFreighterApi(): Promise<FreighterApi> {
+  if (!freighterApiPromise) {
+    freighterApiPromise = import('@stellar/freighter-api')
+  }
+  return freighterApiPromise
+}
+
+type HorizonServer = InstanceType<
+  typeof import('@stellar/stellar-sdk').Horizon.Server
+>
+let horizonPromise: Promise<HorizonServer> | null = null
+function loadHorizon(): Promise<HorizonServer> {
+  if (!horizonPromise) {
+    horizonPromise = import('@stellar/stellar-sdk').then(
+      ({ Horizon }) => new Horizon.Server(HORIZON_URL)
+    )
+  }
+  return horizonPromise
+}
 
 /**
  * Safely extracts and normalizes transaction memo data from Horizon transaction records or embedded operation objects.
@@ -82,6 +103,7 @@ export function useFreighterWallet() {
   // Fetch real balances from Horizon
   const fetchBalances = useCallback(async (publicKey: string) => {
     try {
+      const horizon = await loadHorizon()
       const account = await horizon.loadAccount(publicKey)
 
       let xlm = '0'
@@ -117,6 +139,7 @@ export function useFreighterWallet() {
   const fetchTransactions = useCallback(async (publicKey: string) => {
     setTxLoading(true)
     try {
+      const horizon = await loadHorizon()
       const ops = await horizon
         .operations()
         .forAccount(publicKey)
@@ -209,6 +232,7 @@ export function useFreighterWallet() {
     setWallet((prev: WalletState) => ({ ...prev, loading: true, error: null }))
 
     try {
+      const { isConnected, requestAccess, getAddress, getNetwork } = await loadFreighterApi()
       const connected = await isConnected()
       if (!connected.isConnected) {
         throw new Error(
@@ -275,6 +299,7 @@ export function useFreighterWallet() {
   useEffect(() => {
     const check = async () => {
       try {
+        const { isConnected, getAddress, getNetwork } = await loadFreighterApi()
         const connected = await isConnected()
         if (connected.isConnected) {
           const addr = await getAddress()

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+}))
+
+const { mockGetNetworkDetails, mockSignAuthEntry } = vi.hoisted(() => ({
+  mockGetNetworkDetails: vi.fn(),
+  mockSignAuthEntry: vi.fn(),
+}))
+vi.mock('@stellar/freighter-api', () => ({
+  getNetworkDetails: (...args: any[]) => mockGetNetworkDetails(...args),
+  signAuthEntry: (...args: any[]) => mockSignAuthEntry(...args),
+}))
+
+vi.mock('@stellar/stellar-sdk', () => ({
+  Networks: { PUBLIC: 'Public Global Stellar Network ; September 2015', TESTNET: 'Test SDF Network ; September 2015' },
+}))
+
+const { mockCreatePaymentPayload, mockGetPaymentRequiredResponse, mockEncodePaymentSignatureHeader } = vi.hoisted(() => ({
+  mockCreatePaymentPayload: vi.fn(),
+  mockGetPaymentRequiredResponse: vi.fn(),
+  mockEncodePaymentSignatureHeader: vi.fn(),
+}))
+vi.mock('@x402/fetch', () => ({
+  x402Client: class {
+    register() {
+      return this
+    }
+    createPaymentPayload(...args: any[]) {
+      return mockCreatePaymentPayload(...args)
+    }
+  },
+  x402HTTPClient: class {
+    getPaymentRequiredResponse(...args: any[]) {
+      return mockGetPaymentRequiredResponse(...args)
+    }
+    encodePaymentSignatureHeader(...args: any[]) {
+      return mockEncodePaymentSignatureHeader(...args)
+    }
+  },
+}))
+vi.mock('@x402/stellar/exact/client', () => ({
+  ExactStellarScheme: class {},
+}))
+
+import { useSearch } from './useSearch'
+
+const WALLET = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+
+// This test environment's window.localStorage has every method undefined
+// (a pre-existing jsdom/vitest quirk, not introduced here — see
+// useFreighterWallet's sibling issue in the StellarCred repo for the same
+// class of bug). useSearch.ts's own receipt persistence already wraps
+// localStorage access in try/catch for exactly this kind of failure, so it
+// silently no-ops rather than throwing — but that also means the real
+// storage can't be used to verify the receipt actually gets written. Stub a
+// minimal in-memory implementation instead.
+function stubLocalStorage() {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  })
+}
+
+describe('useSearch — lazy-loaded x402 payment flow (#336)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stubLocalStorage()
+    mockGetNetworkDetails.mockResolvedValue({ network: 'TESTNET' })
+    mockCreatePaymentPayload.mockResolvedValue({ payload: 'signed' })
+    mockGetPaymentRequiredResponse.mockReturnValue({ accepts: [] })
+    mockEncodePaymentSignatureHeader.mockReturnValue({ 'X-PAYMENT': 'encoded' })
+  })
+
+  it('errors immediately without a connected wallet, never loading the payment SDKs', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(null))
+    await act(async () => {
+      await result.current.search('test query')
+    })
+
+    expect(result.current.session.status).toBe('error')
+    expect(mockGetNetworkDetails).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects when Freighter is on the wrong network', async () => {
+    mockGetNetworkDetails.mockResolvedValue({ network: 'PUBLIC' })
+    vi.stubGlobal('fetch', vi.fn())
+
+    const { result } = renderHook(() => useSearch(WALLET))
+    await act(async () => {
+      await result.current.search('test query')
+    })
+
+    expect(result.current.session.status).toBe('error')
+    expect(result.current.session.error).toMatch(/Switch Freighter to TESTNET/)
+    vi.unstubAllGlobals()
+  })
+
+  it('returns results directly when the server responds without a 402 challenge', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ results: [{ title: 'Result A' }], suggestions: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET))
+    await act(async () => {
+      await result.current.search('free query')
+    })
+
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+    expect(result.current.session.results).toEqual([{ title: 'Result A' }])
+    expect(result.current.session.txHash).toBeNull()
+    vi.unstubAllGlobals()
+  })
+
+  it('completes the full 402 payment flow and persists a receipt', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        status: 402,
+        headers: { get: () => null },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          results: [{ title: 'Paid Result' }],
+          suggestions: [],
+          txHash: 'deadbeef',
+          paidAmount: '0.001',
+          network: 'stellar:testnet',
+        }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSearch(WALLET))
+    await act(async () => {
+      await result.current.search('paid query')
+    })
+
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+    expect(result.current.session.txHash).toBe('deadbeef')
+    expect(mockCreatePaymentPayload).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const receipts = JSON.parse(localStorage.getItem('stellarsearch_receipts') || '[]')
+    expect(receipts).toHaveLength(1)
+    expect(receipts[0].txHash).toBe('deadbeef')
+    vi.unstubAllGlobals()
+  })
+
+  it('reset returns the session to idle', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ results: [], suggestions: [] }),
+    }))
+
+    const { result } = renderHook(() => useSearch(WALLET))
+    await act(async () => {
+      await result.current.search('q')
+    })
+    await waitFor(() => expect(result.current.session.status).toBe('complete'))
+
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.session.status).toBe('idle')
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -12,12 +12,40 @@
 
 import { useState, useCallback }              from 'react'
 import { toast }                               from 'sonner'
-import { x402Client, x402HTTPClient }          from '@x402/fetch'
-import { ExactStellarScheme }                  from '@x402/stellar/exact/client'
-import { signAuthEntry, getNetworkDetails }    from '@stellar/freighter-api'
-import { Networks }                            from '@stellar/stellar-sdk'
 import { Buffer }                              from 'buffer'
 import { IS_MAINNET, EXPECTED_WALLET_NETWORK, explorerTxUrl } from '../lib/stellar'
+
+// The x402/Freighter/Stellar payment stack is loaded on demand, on the first
+// call to `search()`, rather than imported statically — every page load
+// previously pulled all of it into the main bundle even for a user who never
+// runs a paid search (#336). Memoized so a second search in the same session
+// doesn't re-import.
+let paymentDepsPromise: Promise<{
+  x402Client: typeof import('@x402/fetch').x402Client
+  x402HTTPClient: typeof import('@x402/fetch').x402HTTPClient
+  ExactStellarScheme: typeof import('@x402/stellar/exact/client').ExactStellarScheme
+  signAuthEntry: typeof import('@stellar/freighter-api').signAuthEntry
+  getNetworkDetails: typeof import('@stellar/freighter-api').getNetworkDetails
+  Networks: typeof import('@stellar/stellar-sdk').Networks
+}> | null = null
+function loadPaymentDeps() {
+  if (!paymentDepsPromise) {
+    paymentDepsPromise = Promise.all([
+      import('@x402/fetch'),
+      import('@x402/stellar/exact/client'),
+      import('@stellar/freighter-api'),
+      import('@stellar/stellar-sdk'),
+    ]).then(([fetchMod, schemeMod, freighterMod, stellarMod]) => ({
+      x402Client: fetchMod.x402Client,
+      x402HTTPClient: fetchMod.x402HTTPClient,
+      ExactStellarScheme: schemeMod.ExactStellarScheme,
+      signAuthEntry: freighterMod.signAuthEntry,
+      getNetworkDetails: freighterMod.getNetworkDetails,
+      Networks: stellarMod.Networks,
+    }))
+  }
+  return paymentDepsPromise
+}
 
 const SERVER_URL = (import.meta as any).env?.VITE_SERVER_URL ?? (
   typeof window !== 'undefined' && window.location.origin.includes('vercel.app') 
@@ -89,6 +117,11 @@ export function useSearch(walletAddress: string | null = null) {
       if (!walletAddress) throw new Error('Connect your Freighter wallet first.')
 
       console.log('🔍 Starting search with wallet:', walletAddress)
+
+      const {
+        x402Client, x402HTTPClient, ExactStellarScheme,
+        signAuthEntry, getNetworkDetails, Networks,
+      } = await loadPaymentDeps()
 
       // Step 1 — verify Freighter is on correct network
       const net = await getNetworkDetails()


### PR DESCRIPTION
`@stellar/freighter-api` and `@stellar/stellar-sdk` were imported statically at module scope in `useFreighterWallet.ts` and `useSearch.ts`, both of which `App.tsx` wires in unconditionally — so every page load (docs, browsing before connecting a wallet) pulled both into the main bundle, along with `@x402/fetch` and `@x402/stellar/exact/client`, which `useSearch.ts` only actually needs inside its `search()` callback.

- `useFreighterWallet.ts`: `loadFreighterApi()`/`loadHorizon()` memoized dynamic-import loaders replace the top-level imports and the module-scope `new Horizon.Server(...)`. `connect()`, the mount-time auto-reconnect check, `fetchBalances`, and `fetchTransactions` now `await` the loader instead of referencing a static import — current connection behavior (including auto-detecting an existing session on mount) is unchanged, just deferred to a separate chunk instead of shipping in the main one.
- `useSearch.ts`: the whole x402/Freighter/Stellar payment stack (`x402Client`, `x402HTTPClient`, `ExactStellarScheme`, `signAuthEntry`, `getNetworkDetails`, `Networks`) moves behind one memoized `loadPaymentDeps()`, called at the top of `search()` right after the existing wallet-address check — so an unauthenticated search still fails fast without loading any of it.

**Measured effect** (`vite build`, before vs. after):

| | before | after |
|---|---|---|
| main bundle | one 2,451 kB chunk (688 kB gzip) | split into several chunks |
| `@stellar/stellar-sdk` | bundled into the main chunk | its own 1,016 kB chunk (278 kB gzip), no longer part of what every page load fetches |

**Tests:** `useFreighterWallet.test.ts`'s existing 11 tests pass unchanged (`vi.mock` intercepts both static and dynamic imports of the same specifier transparently, so no test changes were needed there). Added `useSearch.test.ts` (new — the hook had no prior coverage): no-wallet short-circuit without ever loading the payment SDKs, wrong-network rejection, a non-402 (free) response path, the full 402 payment flow with receipt persistence, and reset.

Full suite: 203/204 pass — the one failure is `mcp-server/tools.test.ts`'s pre-existing, unrelated mock gap (`ListResourcesRequestSchema` missing from a test's `@modelcontextprotocol/sdk/types.js` mock), confirmed present on a clean `main` checkout before this change. `tsc --noEmit` is clean.

Fixes #336
Closes #334
Closes #335
Closes #337

