### PR TITLE
feat(ui): move focus to results or error heading after search

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,16 @@ When upstream search providers auto-correct or suggest queries ("Did you mean?")
 - **Did You Mean Suggestions**: Displays the suggested correction alongside "Search Suggestion" (which invokes the explicit Freighter confirmation flow) and a "Dismiss" action that closes the suggestion with **0 additional cost and no second payment**.
 - No automatic or silent payments are ever executed.
 
+### Search focus management (#150)
+
+After an asynchronous search settles, keyboard and screen-reader focus moves to a **results heading** on success and to the **error alert** (`role="alert"`) on failure — so assistive tech users land directly on the outcome instead of the now-disabled search input.
+
+- Focus moves **only** on the async completion transition (`searching` → `complete` / `error`), never while typing, signing, or during manual navigation.
+- The results heading (`h2`, `tabIndex=-1`) is focusable and is rendered even for a successful search with zero results, so focus always has a destination.
+- The error alert is focusable (`tabIndex=-1`) with `role="alert"` so failures are announced and reachable.
+
+See `src/pages/SearchPage.tsx` (error focus) and `src/components/search/SearchResults.tsx` (results heading focus), covered by `src/pages/SearchPage.test.tsx`.
+
 ---
 
 ## Testing & Coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.3",
         "@testing-library/user-event": "^14.6.6",
@@ -2230,6 +2231,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2243,6 +2245,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2256,6 +2259,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2269,6 +2273,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2282,6 +2287,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2295,6 +2301,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,6 +2315,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,6 +2329,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2334,6 +2343,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2347,6 +2357,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2360,6 +2371,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,6 +2385,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2386,6 +2399,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2399,6 +2413,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2412,6 +2427,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,6 +2441,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,6 +2455,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,6 +2469,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2464,6 +2483,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,6 +2497,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,6 +2511,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2503,6 +2525,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2516,6 +2539,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2529,6 +2553,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,6 +2567,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,7 +2734,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2830,8 +2855,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3086,7 +3110,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -3107,7 +3131,7 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3673,6 +3697,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3689,6 +3714,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3705,6 +3731,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3721,6 +3748,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3737,6 +3765,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3753,6 +3782,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3769,6 +3799,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3785,6 +3816,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3801,6 +3833,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3817,6 +3850,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3833,6 +3867,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3849,6 +3884,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3865,6 +3901,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3881,6 +3918,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3897,6 +3935,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3913,6 +3952,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3929,6 +3969,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3945,6 +3986,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3961,6 +4003,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3977,6 +4020,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5114,7 +5158,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5918,7 +5961,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -6211,8 +6254,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -8471,7 +8513,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9161,7 +9202,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9177,21 +9217,12 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -9376,11 +9407,11 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
-      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
-      "license": "MIT",
-      "peer": true
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
@@ -9576,7 +9607,7 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10522,7 +10553,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^6.0.1",
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.3",
     "@testing-library/user-event": "^14.6.6",

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -142,3 +142,102 @@ describe('SearchPage component', () => {
     expect(searchInput).toBeInTheDocument()
   })
 })
+
+describe('SearchPage focus management (#150)', () => {
+  // Must match EXPECTED_WALLET_NETWORK so the search input is not disabled.
+  const focusedWallet: WalletState = { ...mockWalletConnected, network: 'TESTNET' }
+
+  const baseSession: SearchSession = {
+    query: 'stellar blockchain',
+    results: [],
+    txHash: null,
+    paidAmount: null,
+    status: 'searching',
+    suggestions: [],
+  }
+
+  const result = {
+    id: '1',
+    title: 'Stellar Foundation',
+    url: 'https://stellar.org',
+    description: 'Official site',
+    source: 'stellar.org',
+    relevanceScore: 1,
+  }
+
+  const renderPage = (session: SearchSession) =>
+    render(
+      <SearchPage
+        wallet={focusedWallet}
+        onConnectWallet={vi.fn()}
+        session={session}
+        search={vi.fn()}
+        reset={vi.fn()}
+      />
+    )
+
+  const rerenderPage = (rerender: any, session: SearchSession) =>
+    rerender(
+      <SearchPage
+        wallet={focusedWallet}
+        onConnectWallet={vi.fn()}
+        session={session}
+        search={vi.fn()}
+        reset={vi.fn()}
+      />
+    )
+
+  it('moves focus to the results heading when an async search completes', () => {
+    const { rerender } = renderPage(baseSession)
+
+    rerenderPage(rerender, { ...baseSession, status: 'complete', results: [result], txHash: 'tx_1', paidAmount: '0.001' })
+
+    const heading = screen.getByRole('heading', { level: 2 })
+    expect(heading).toHaveTextContent(/RESULTS/i)
+    expect(document.activeElement).toBe(heading)
+  })
+
+  it('moves focus to a results heading even when the search returned zero results', () => {
+    const { rerender } = renderPage(baseSession)
+    rerenderPage(rerender, { ...baseSession, status: 'complete', results: [] })
+
+    const heading = screen.getByRole('heading', { level: 2 })
+    expect(heading).toHaveTextContent(/0 RESULTS/i)
+    expect(document.activeElement).toBe(heading)
+  })
+
+  it('moves focus to the error alert when a search fails', () => {
+    const { rerender } = renderPage(baseSession)
+    rerenderPage(rerender, { ...baseSession, status: 'error', error: 'Payment failed.' })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent(/Payment failed/)
+    expect(document.activeElement).toBe(alert)
+  })
+
+  it('never steals focus while the user is typing in the search input', () => {
+    const { rerender } = renderPage({ ...baseSession, status: 'complete', results: [result] })
+
+    // Focus the input as if the user clicked into it to type a new query.
+    const input = screen.getByRole('textbox', { name: /search query/i })
+    input.focus()
+    fireEvent.change(input, { target: { value: 'next search' } })
+
+    // No status transition happened — focus must stay on the input.
+    expect(document.activeElement).toBe(input)
+
+    // Even while the search runs (searching), focus is not hijacked by results.
+    rerenderPage(rerender, { ...baseSession, status: 'searching', results: [] })
+    expect(document.activeElement).not.toBe(screen.queryByRole('heading', { level: 2 }))
+    expect(document.activeElement).not.toBe(screen.queryByRole('alert'))
+  })
+
+  it('moves focus to the results heading again after a follow-up search completes', () => {
+    const { rerender } = renderPage({ ...baseSession, status: 'complete', results: [result] })
+
+    rerenderPage(rerender, { ...baseSession, status: 'searching', results: [] })
+    rerenderPage(rerender, { ...baseSession, status: 'complete', results: [result, { ...result, id: '2' }] })
+
+    expect(document.activeElement).toBe(screen.getByRole('heading', { level: 2 }))
+  })
+})

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { Search, Zap, AlertCircle } from 'lucide-react'
@@ -31,6 +31,21 @@ export function SearchPage({ wallet, onConnectWallet, session, search, reset }: 
   const { t } = useTranslation('search')
   const [dismissedSuggestion, setDismissedSuggestion] = useState(false)
   const [searchMode, setSearchMode] = useState<SearchMode>('web')
+
+  // #150 — after an async search settles, move keyboard/screen-reader focus to
+  // the error alert (SearchResults moves focus to the results heading on
+  // success). Focus only moves on the transition into `error`; it is never
+  // stolen while typing, signing, or during manual navigation.
+  const errorRef       = useRef<HTMLDivElement>(null)
+  const prevStatusRef  = useRef(session.status)
+
+  useEffect(() => {
+    const prevStatus = prevStatusRef.current
+    prevStatusRef.current = session.status
+    if (prevStatus !== 'error' && session.status === 'error' && errorRef.current) {
+      errorRef.current.focus()
+    }
+  }, [session.status])
 
   const handleSearch = (query: string, freshness?: string) => {
     setDismissedSuggestion(false)
@@ -140,7 +155,12 @@ export function SearchPage({ wallet, onConnectWallet, session, search, reset }: 
             <PaymentFlowVisualizer session={session} />
 
             {session.status === 'error' && (
-              <div className="flex items-center gap-3 p-4 rounded-xl border border-red-500/25 bg-red-500/5">
+              <div
+                ref={errorRef}
+                role="alert"
+                tabIndex={-1}
+                className="flex items-center gap-3 p-4 rounded-xl border border-red-500/25 bg-red-500/5 focus:outline-none"
+              >
                 <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
                 <p className="text-sm text-red-300">{session.error}</p>
               </div>


### PR DESCRIPTION
## Summary
**Closes #150**

Moves keyboard/screen-reader focus after an asynchronous search settles:
- **Success** → focus lands on a focusable results heading (`h2`, `tabIndex=-1`) rendered by `SearchResults` (also rendered for a successful zero-result search so focus always has a destination).
- **Failure** → focus lands on the error alert (`role="alert"`, `tabIndex=-1`) in `SearchPage`.

Focus only moves on the `searching → complete/error` transition, so it is never stolen while typing, signing, or during manual navigation.

Also fixes pre-existing invalid JSX (nested, unclosed `<button>` in the "NEW SEARCH" area) that prevented `SearchPage.test.tsx` from parsing, and pins `@testing-library/dom` (peer of `@testing-library/jest-dom`) so the component test suite can load.

## Files changed
- `src/pages/SearchPage.tsx` — error alert ref/focus, fixed new-search button, `useRef`/`useEffect` transition tracking
- `src/components/search/SearchResults.tsx` — focusable results heading + completion focus effect
- `src/pages/SearchPage.test.tsx` — 5 new focus-management tests
- `README.md` — accessibility section documenting the behavior
- `package.json` / `package-lock.json` — pin `@testing-library/dom`

## Verification
- `npm test`: 27 files / 278 tests pass
- `SearchPage.test.tsx`: 8 tests pass, including focus-moves-on-complete, focus-moves-on-error, zero-result heading focus, no-focus-steal-while-typing, and follow-up search re-focus
- Note: `tsc --noEmit` fails repo-wide on `tsconfig.json` (`baseUrl` removed in TypeScript 7) — pre-existing on main, unrelated to this change