### PR TITLE
fix: abort stale horizon requests when active wallet changes

### DIFF
--- a/src/hooks/useFreighterWallet.test.ts
+++ b/src/hooks/useFreighterWallet.test.ts
@@ -22,7 +22,7 @@ const { mockLoadAccount, mockOperationsCall, mockTransactionsCall, mockSingleTra
   mockSingleTransactionCall: vi.fn(),
 }))
 
-vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+vi.mock('@stellar/stellar-sdk', async (importOriginal: any) => {
   const orig: any = await importOriginal()
   class MockHorizonServer {
     loadAccount = mockLoadAccount
@@ -285,5 +285,69 @@ describe('useFreighterWallet — wallet payment readiness', () => {
 
     expect(result.current.transactions[2].hash).toBe('ghi789')
     expect(result.current.transactions[2].memo).toBeUndefined()
+  })
+
+  it('prevents stale horizon responses from overwriting new-account state', async () => {
+    mockIsConnected.mockResolvedValue({ isConnected: true })
+    mockRequestAccess.mockResolvedValue({})
+    mockGetNetwork.mockResolvedValue({ network: 'TESTNET' })
+    mockOperationsCall.mockResolvedValue({ records: [] })
+    mockTransactionsCall.mockResolvedValue({ records: [] })
+    
+    let resolveFirst: any;
+    const firstPromise = new Promise(resolve => resolveFirst = resolve)
+    let resolveSecond: any;
+    const secondPromise = new Promise(resolve => resolveSecond = resolve)
+
+    mockLoadAccount.mockImplementation(async (pubKey) => {
+      if (pubKey === 'OLD_ACCOUNT') {
+        await firstPromise
+        return {
+          balances: [{ asset_type: 'native', balance: '10.0000' }],
+        }
+      } else if (pubKey === 'NEW_ACCOUNT') {
+        await secondPromise
+        return {
+          balances: [{ asset_type: 'native', balance: '20.0000' }],
+        }
+      }
+      return { balances: [] }
+    })
+
+    const { result } = renderHook(() => useFreighterWallet())
+    
+    // Connect first time (OLD_ACCOUNT)
+    mockGetAddress.mockResolvedValue({ address: 'OLD_ACCOUNT', error: undefined })
+    let connectPromise: Promise<void>;
+    act(() => {
+      connectPromise = result.current.connect()
+    })
+    
+    // Connect second time (NEW_ACCOUNT) BEFORE first responds
+    mockGetAddress.mockResolvedValue({ address: 'NEW_ACCOUNT', error: undefined })
+    let connectPromise2: Promise<void>;
+    act(() => {
+      connectPromise2 = result.current.connect()
+    })
+
+    // Now resolve them out of order (NEW_ACCOUNT resolves first, then OLD_ACCOUNT)
+    resolveSecond()
+    await act(async () => {
+      await connectPromise2
+    })
+    
+    // Wait for the state to reflect NEW_ACCOUNT
+    await waitFor(() => expect(result.current.wallet.xlmBalance).toBe('20.0000'))
+    expect(result.current.wallet.publicKey).toBe('NEW_ACCOUNT')
+    
+    // Now resolve OLD_ACCOUNT
+    resolveFirst()
+    await act(async () => {
+      await connectPromise
+    })
+    
+    // State should still be NEW_ACCOUNT's balance
+    expect(result.current.wallet.xlmBalance).toBe('20.0000')
+    expect(result.current.wallet.publicKey).toBe('NEW_ACCOUNT')
   })
 })

--- a/src/hooks/useFreighterWallet.ts
+++ b/src/hooks/useFreighterWallet.ts
@@ -4,7 +4,7 @@
  * Fetches live balances from Stellar Horizon
  */
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { HORIZON_URL, USDC_ISSUER } from '../lib/stellar'
 import type { WalletState, StellarTransaction } from '../types'
 
@@ -100,11 +100,16 @@ export function useFreighterWallet() {
   const [transactions, setTransactions] = useState<StellarTransaction[]>([])
   const [txLoading, setTxLoading] = useState(false)
 
+  const balanceGenRef = useRef(0)
+
   // Fetch real balances from Horizon
   const fetchBalances = useCallback(async (publicKey: string) => {
+    const currentGen = ++balanceGenRef.current
     try {
       const horizon = await loadHorizon()
       const account = await horizon.loadAccount(publicKey)
+
+      if (balanceGenRef.current !== currentGen) return
 
       let xlm = '0'
       let usdc = '0'
@@ -128,6 +133,7 @@ export function useFreighterWallet() {
         error: null,
       }))
     } catch (err: any) {
+      if (balanceGenRef.current !== currentGen) return
       setWallet((prev: WalletState) => ({
         ...prev,
         error: err.message || 'Failed to load account',
@@ -135,8 +141,11 @@ export function useFreighterWallet() {
     }
   }, [])
 
+  const txGenRef = useRef(0)
+
   // Fetch real transaction history from Horizon with expanded transaction memo lookup
   const fetchTransactions = useCallback(async (publicKey: string) => {
+    const currentGen = ++txGenRef.current
     setTxLoading(true)
     try {
       const horizon = await loadHorizon()
@@ -147,6 +156,8 @@ export function useFreighterWallet() {
         .limit(15)
         .call()
 
+      if (txGenRef.current !== currentGen) return
+
       // Expanded transaction lookup to reliably retrieve memos
       const txMap = new Map<string, { memo?: unknown; memo_type?: unknown }>()
       try {
@@ -156,6 +167,8 @@ export function useFreighterWallet() {
           .order('desc')
           .limit(15)
           .call()
+
+        if (txGenRef.current !== currentGen) return
 
         for (const txRecord of txPage.records) {
           if (txRecord && typeof txRecord === 'object' && 'hash' in txRecord) {
@@ -196,6 +209,8 @@ export function useFreighterWallet() {
         )
       }
 
+      if (txGenRef.current !== currentGen) return
+
       const txs: StellarTransaction[] = ops.records
         .filter((op: any) => op.type === 'payment' || op.type === 'create_account')
         .map((op: any) => {
@@ -221,9 +236,12 @@ export function useFreighterWallet() {
 
       setTransactions(txs)
     } catch {
+      if (txGenRef.current !== currentGen) return
       setTransactions([])
     } finally {
-      setTxLoading(false)
+      if (txGenRef.current === currentGen) {
+        setTxLoading(false)
+      }
     }
   }, [])
 


### PR DESCRIPTION
Closes #129 

Resolves a race condition in the `useFreighterWallet` hook where stale Horizon responses could overwrite the state of a newly selected account.

**Changes:**
* Added generation tokens (`balanceGenRef` and `txGenRef`) to `fetchBalances` and `fetchTransactions`.
* Requests that resolve after the active account has changed (or after a new fetch is initiated) are now aborted/ignored.
* Added a race-condition test in `useFreighterWallet.test.ts` to prove that old, out-of-order responses cannot update new-account state.