### PR TITLE
feat: add free /pricing endpoint for pre-flight payment discovery

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -7,6 +7,13 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
     description: 'Pay-per-query web search for AI agents via x402 on Stellar',
     endpoints: {
       'GET /api/search?q=<query>': '0.001 USDC via x402',
+      'GET /api/images?q=<query>': '0.001 USDC via x402 — image results',
+      'GET /api/news?q=<query>': '0.001 USDC via x402 — news articles',
+      'POST /api/search/batch': '0.001 USDC per query (max 10), JSONL streaming',
+      'POST /api/jobs': '0.001 USDC via x402 — async job, returns 202',
+      'GET /api/jobs/:id': 'Job status + verified payment state',
+      'GET /api/jobs': 'List recent jobs (capped at 50)',
+      'GET /api/pricing': 'Free — pricing info, scheme, and valid endpoints',
       'POST /api/ai/chat': 'Groq AI — free',
       'GET /api/health': 'Live server stats',
     },

--- a/api/pricing.ts
+++ b/api/pricing.ts
@@ -1,0 +1,33 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { NETWORK, AMOUNT_USDC, AMOUNT_STROOPS, USDC_CONTRACT } from '../src/lib/constants'
+
+const RECEIVING_ADDRESS = process.env.STELLAR_RECEIVING_ADDRESS || ''
+const FACILITATOR_URL = process.env.FACILITATOR_URL || 'https://www.x402.org/facilitator'
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  res.json({
+    version: '1.0.0',
+    endpoints: [
+      { method: 'GET',  path: '/api/search',        description: 'Web search' },
+      { method: 'GET',  path: '/api/images',        description: 'Image search' },
+      { method: 'GET',  path: '/api/news',          description: 'News search' },
+      { method: 'POST', path: '/api/search/batch',  description: 'Batch search (up to 10 queries, JSONL streaming)' },
+      { method: 'POST', path: '/api/jobs',          description: 'Async search job with webhook callback' },
+    ],
+    schemes: [{
+      network:        NETWORK,
+      scheme:         'exact',
+      assetContract:  USDC_CONTRACT,
+      amountStroops:  AMOUNT_STROOPS,
+      amountUsdc:     AMOUNT_USDC,
+      payTo:          RECEIVING_ADDRESS,
+      maxTimeoutSeconds: 300,
+    }],
+    facilitatorUrl: FACILITATOR_URL,
+    note: 'All paid endpoints require 0.001 USDC per query via x402 on Stellar. Batch requests scale linearly.',
+  })
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -52,6 +52,7 @@ import type {
   BatchJsonlDoneEvent,
   SearchJob,
   JobStatus,
+  PricingInfo,
 } from '../src/types/index.js'
 import { buildReconciliationRecord, type ReconciliationRoute } from '../src/lib/reconciliation.js'
 import { appendReconciliationRecord } from './reconciliationStore.js'
@@ -1188,6 +1189,32 @@ app.post('/ai/chat', async (req: Request, res: Response) => {
 
 
 
+// ─── GET /pricing — free pre-flight pricing info (no payment required) ─────
+app.get('/pricing', (_req: Request, res: Response) => {
+  const info: PricingInfo = {
+    version: '1.0.0',
+    endpoints: [
+      { method: 'GET',  path: '/search',        description: 'Web search' },
+      { method: 'GET',  path: '/images',        description: 'Image search' },
+      { method: 'GET',  path: '/news',          description: 'News search' },
+      { method: 'POST', path: '/search/batch',  description: 'Batch search (up to 10 queries, JSONL streaming)' },
+      { method: 'POST', path: '/jobs',          description: 'Async search job with webhook callback' },
+    ],
+    schemes: [{
+      network:        NETWORK,
+      scheme:         'exact',
+      assetContract:  USDC_CONTRACT,
+      amountStroops:  AMOUNT_STROOPS,
+      amountUsdc:     AMOUNT_USDC,
+      payTo:          RECEIVING_ADDRESS,
+      maxTimeoutSeconds: 300,
+    }],
+    facilitatorUrl: FACILITATOR_URL,
+    note: 'All paid endpoints require 0.001 USDC per query via x402 on Stellar. Batch requests scale linearly.',
+  }
+  res.json(info)
+})
+
 // ─── GET / ────────────────────────────────────────────────────────────────
 app.get('/', (_req: Request, res: Response) => {
   res.json({
@@ -1202,6 +1229,7 @@ app.get('/', (_req: Request, res: Response) => {
       'POST /jobs':            '0.001 USDC via x402 — async job, returns 202 + statusUrl + verified payment state',
       'GET /jobs/:id':         'Job status + verified payment state (webhook signed, replay/SSRF protected)',
       'GET /jobs':             'List recent jobs (capped at 50)',
+      'GET /pricing':          'Free — pricing info, scheme, and valid endpoints',
       'POST /ai/chat':         'Groq AI — free',
       'GET /health':           'Live server stats',
     },

--- a/server/pricing.test.ts
+++ b/server/pricing.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import request from 'supertest'
+
+// Mock x402 and Groq before importing app
+vi.mock('@x402/express', () => ({
+  paymentMiddlewareFromConfig: () => (_req: any, _res: any, next: any) => next(),
+}))
+vi.mock('@x402/core/server', () => ({
+  HTTPFacilitatorClient: class { constructor(_opts: any) {} },
+}))
+vi.mock('@x402/stellar/exact/server', () => ({
+  ExactStellarScheme: class { constructor() {} },
+}))
+vi.mock('groq-sdk', () => ({
+  default: class {
+    chat = { completions: { create: vi.fn() } }
+  },
+}))
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+// Need to set env before import
+process.env.STELLAR_RECEIVING_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4AFL5MNSF3GAKGOWG5W2LBBGCS2TDPZOM3'
+process.env.SERPER_API_KEY = 'test-serper-key'
+process.env.GROQ_API_KEY = 'gsk_test'
+
+let app: any
+
+beforeAll(async () => {
+  const mod = await import('./index.js')
+  app = mod.default
+})
+
+describe('GET /pricing', () => {
+  it('returns pricing info without payment required', async () => {
+    const res = await request(app).get('/pricing')
+    expect(res.status).toBe(200)
+    expect(res.body.version).toBe('1.0.0')
+    expect(Array.isArray(res.body.endpoints)).toBe(true)
+    expect(Array.isArray(res.body.schemes)).toBe(true)
+    expect(typeof res.body.facilitatorUrl).toBe('string')
+    expect(typeof res.body.note).toBe('string')
+  })
+
+  it('lists all paid endpoints', async () => {
+    const res = await request(app).get('/pricing')
+    const endpoints = res.body.endpoints
+    expect(endpoints.length).toBe(5)
+    
+    const paths = endpoints.map((e: any) => e.path)
+    expect(paths).toContain('/search')
+    expect(paths).toContain('/images')
+    expect(paths).toContain('/news')
+    expect(paths).toContain('/search/batch')
+    expect(paths).toContain('/jobs')
+  })
+
+  it('each endpoint has method, path, and description', async () => {
+    const res = await request(app).get('/pricing')
+    for (const endpoint of res.body.endpoints) {
+      expect(typeof endpoint.method).toBe('string')
+      expect(typeof endpoint.path).toBe('string')
+      expect(typeof endpoint.description).toBe('string')
+    }
+  })
+
+  it('scheme contains required fields from validated config', async () => {
+    const res = await request(app).get('/pricing')
+    const scheme = res.body.schemes[0]
+    
+    expect(scheme.network).toMatch(/stellar:/)
+    expect(scheme.scheme).toBe('exact')
+    expect(typeof scheme.assetContract).toBe('string')
+    expect(scheme.assetContract.length).toBeGreaterThan(0)
+    expect(scheme.amountStroops).toBe('10000')
+    expect(scheme.amountUsdc).toBe('0.001')
+    expect(typeof scheme.payTo).toBe('string')
+    expect(scheme.payTo.startsWith('G')).toBe(true)
+    expect(scheme.maxTimeoutSeconds).toBe(300)
+  })
+
+  it('facilitator URL is configured', async () => {
+    const res = await request(app).get('/pricing')
+    expect(res.body.facilitatorUrl).toBe('https://www.x402.org/facilitator')
+  })
+
+  it('does not require payment (no 402)', async () => {
+    const res = await request(app).get('/pricing')
+    expect(res.status).not.toBe(402)
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,3 +327,29 @@ export interface SavedResearchItem {
   tags: string[]
 }
 export type SearchMode = 'web' | 'images' | 'news'
+
+// ─── Pricing info endpoint (free, pre-flight) ─────────────────────────────
+
+export interface PricingEndpointInfo {
+  method: string
+  path: string
+  description: string
+}
+
+export interface PricingSchemeInfo {
+  network: string
+  scheme: string
+  assetContract: string
+  amountStroops: string
+  amountUsdc: string
+  payTo: string
+  maxTimeoutSeconds: number
+}
+
+export interface PricingInfo {
+  version: string
+  endpoints: PricingEndpointInfo[]
+  schemes: PricingSchemeInfo[]
+  facilitatorUrl: string
+  note: string
+}


### PR DESCRIPTION
## Payment operations & economic controls

### Context

Agents currently learn price details only after requesting a paid resource and parsing a 402 challenge. This adds a free `GET /pricing` endpoint that exposes payment metadata upfront, so clients can discover cost, scheme, and network requirements before attempting a paid request.

### Changes

- **New types** — `PricingInfo`, `PricingEndpointInfo`, `PricingSchemeInfo` in `src/types/index.ts`
- **Express endpoint** — `GET /pricing` in `server/index.ts` (no payment required)
- **Vercel endpoint** — `GET /api/pricing` in `api/pricing.ts` (no payment required)
- **Root docs updated** — both Express and Vercel root responses now list the `/pricing` endpoint
- **Tests** — 6 new tests in `server/pricing.test.ts` covering response shape, scheme fields, and absence of 402

### Acceptance Criteria

- [x] A free endpoint lists endpoint, amount, asset contract, network, scheme, and validity
- [x] Values come from the same validated configuration used by x402 middleware
- [x] Automated coverage and documentation are updated for changed behavior

### Response shape

```json
{
  "version": "1.0.0",
  "endpoints": [
    { "method": "GET", "path": "/search", "description": "Web search" },
    { "method": "GET", "path": "/images", "description": "Image search" },
    { "method": "GET", "path": "/news", "description": "News search" },
    { "method": "POST", "path": "/search/batch", "description": "Batch search (up to 10 queries, JSONL streaming)" },
    { "method": "POST", "path": "/jobs", "description": "Async search job with webhook callback" }
  ],
  "schemes": [{
    "network": "stellar:testnet",
    "scheme": "exact",
    "assetContract": "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
    "amountStroops": "10000",
    "amountUsdc": "0.001",
    "payTo": "G...",
    "maxTimeoutSeconds": 300
  }],
  "facilitatorUrl": "https://www.x402.org/facilitator",
  "note": "All paid endpoints require 0.001 USDC per query via x402 on Stellar."
}

## Closes #310