### PR TITLE
Add opt-in pre-push CI checks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+# Opt-in: set SKIP_PREPUSH_CHECK=1 for an emergency bypass.
+if [ "${SKIP_PREPUSH_CHECK:-0}" = "1" ]; then
+  exit 0
+fi
+
+npm run prepush:check

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "prepush:check": "npm run build && npm test && npm run lint && npm run typecheck",
     "config:check": "tsx scripts/check-config.ts",
     "lint": "eslint .",
     "test": "vitest run",


### PR DESCRIPTION
## Summary\n\nAdds a documented pre-push fast suite for build, tests, lint, and typechecks with an emergency bypass.\n\nCloses #206\n\n## Verification\n\n- git diff --check\n- Added or updated focused automated coverage where applicable.