### PR TITLE
Add contextual recovery actions for paid search failures

### DIFF
--- a/docs/search-error-recovery.md
+++ b/docs/search-error-recovery.md
@@ -1,0 +1,8 @@
+# Search error recovery
+
+The browser search flow records a stable `errorCode` on failed requests. The
+Search page uses it to offer the most relevant next action: wallet/network
+errors route to connection guidance, balance errors start a fresh flow, and
+provider or request failures offer a retry for the same query. A retry only
+starts a new payment flow after the previous request has failed; the existing
+cross-tab search lock continues to prevent concurrent duplicate payments.

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -24,6 +24,7 @@ const SOROBAN_RPC_MAINNET = 'https://soroban-rpc.mainnet.stellar.org' // Or anot
 const SOROBAN_RPC_URL = IS_MAINNET ? SOROBAN_RPC_MAINNET : SOROBAN_RPC_TESTNET
 
 import type { SearchResult, SearchReceipt, SearchResponse, PaymentStep, SearchSession, SearchMode } from '../types'
+import { classifySearchError } from '../types'
 
 export type { SearchResult, SearchReceipt, PaymentStep, SearchSession }
 
@@ -338,6 +339,7 @@ export function useSearch(walletAddress: string | null = null) {
         ...prev,
         status: 'error',
         error:  msg,
+        errorCode: classifySearchError(err),
       }))
     } finally {
       inFlightRef.current = false

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -162,7 +162,26 @@ export function SearchPage({ wallet, onConnectWallet, session, search, reset }: 
                 className="flex items-center gap-3 p-4 rounded-xl border border-red-500/25 bg-red-500/5 focus:outline-none"
               >
                 <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
-                <p className="text-sm text-red-300">{session.error}</p>
+                <div className="flex-1">
+                  <p className="text-sm text-red-300">{session.error}</p>
+                  {session.errorCode && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (session.errorCode === 'wallet_required' || session.errorCode === 'network_mismatch') onConnectWallet()
+                        else if (session.errorCode === 'payment_rejected' || session.errorCode === 'provider_unavailable' || session.errorCode === 'request_failed') search(session.query, undefined, searchMode === 'web' ? 5 : 10, searchMode)
+                        else handleReset()
+                      }}
+                      className="mt-2 text-xs font-display tracking-wider text-neon-cyan hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan rounded"
+                    >
+                      {session.errorCode === 'wallet_required' ? 'CONNECT WALLET' :
+                       session.errorCode === 'network_mismatch' ? 'CHECK NETWORK' :
+                       session.errorCode === 'insufficient_balance' ? 'VIEW BALANCE' :
+                       session.errorCode === 'payment_rejected' ? 'RETRY PAYMENT' :
+                       session.errorCode === 'provider_unavailable' ? 'RETRY PROVIDER' : 'START NEW SEARCH'}
+                    </button>
+                  )}
+                </div>
               </div>
             )}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,8 +22,29 @@ export interface SearchSession {
   status: 'idle' | 'searching' | 'done' | 'error' | 'complete'
   step?: PaymentStep
   error?: string
+  errorCode?: SearchErrorCode
   suggestions?: string[]
   durationMs?: number
+}
+
+export type SearchErrorCode =
+  | 'wallet_required'
+  | 'network_mismatch'
+  | 'insufficient_balance'
+  | 'payment_rejected'
+  | 'payment_failed'
+  | 'provider_unavailable'
+  | 'request_failed'
+
+export function classifySearchError(error: unknown): SearchErrorCode {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+  if (message.includes('connect') && message.includes('wallet')) return 'wallet_required'
+  if (message.includes('switch') && message.includes('freighter')) return 'network_mismatch'
+  if (message.includes('balance') || message.includes('usdc')) return 'insufficient_balance'
+  if (message.includes('reject') || message.includes('denied') || message.includes('cancel')) return 'payment_rejected'
+  if (message.includes('payment failed') || message.includes('402')) return 'payment_failed'
+  if (message.includes('serper') || message.includes('provider') || message.includes('503')) return 'provider_unavailable'
+  return 'request_failed'
 }
 
 export type WalletAccountStatus = 'unfunded' | 'no_trustline' | 'zero_balance' | 'funded'


### PR DESCRIPTION
Closes #144

## Summary
- classify wallet, network, balance, payment, provider, and request failures with stable error codes
- render a contextual recovery action in the search error alert
- preserve the existing search mutex so recovery cannot start concurrent paid requests

## Validation
- `git diff --check`
- Focused Vitest tests are configured but could not run in this environment because dependencies are not installed.