### PR TITLE
Preserve freshness filters for suggestion searches

### DIFF
--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -141,6 +141,21 @@ describe('SearchPage component', () => {
     const searchInput = screen.getByRole('textbox', { name: /search query/i })
     expect(searchInput).toBeInTheDocument()
   })
+
+  it('preserves the active freshness filter for AI suggestions', async () => {
+    const search = vi.fn()
+    const session: SearchSession = {
+      query: 'stellar', results: [{ id: '1', title: 'Result', url: 'https://example.com', description: 'Description', source: 'example.com', relevanceScore: 1 }],
+      txHash: 'tx', paidAmount: '0.001', status: 'complete', suggestions: ['soroban payments'],
+    }
+    render(<SearchPage wallet={mockWalletConnected} onConnectWallet={vi.fn()} session={session} search={search} reset={vi.fn()} />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'pw' } })
+    fireEvent.change(screen.getByRole('textbox', { name: /search query/i }), { target: { value: 'stellar' } })
+    fireEvent.submit(screen.getByRole('search'))
+    fireEvent.click(await screen.findByRole('button', { name: 'soroban payments' }))
+    expect(search).toHaveBeenCalledWith('stellar', 'pw', 5, 'web')
+    expect(search).toHaveBeenCalledWith('soroban payments', 'pw', 5, 'web')
+  })
 })
 
 describe('SearchPage focus management (#150)', () => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -31,6 +31,7 @@ export function SearchPage({ wallet, onConnectWallet, session, search, reset }: 
   const { t } = useTranslation('search')
   const [dismissedSuggestion, setDismissedSuggestion] = useState(false)
   const [searchMode, setSearchMode] = useState<SearchMode>('web')
+  const [activeFreshness, setActiveFreshness] = useState<string | undefined>(undefined)
 
   // #150 — after an async search settles, move keyboard/screen-reader focus to
   // the error alert (SearchResults moves focus to the results heading on
@@ -49,8 +50,12 @@ export function SearchPage({ wallet, onConnectWallet, session, search, reset }: 
 
   const handleSearch = (query: string, freshness?: string) => {
     setDismissedSuggestion(false)
+    // Suggestions are alternate queries, not new filter selections. Keep the
+    // user's visible freshness filter when they choose one.
+    const nextFreshness = freshness ?? activeFreshness
+    if (freshness !== undefined) setActiveFreshness(freshness)
     if (!wallet.connected) { onConnectWallet(); return }
-    search(query, freshness, searchMode === 'web' ? 5 : 10, searchMode)
+    search(query, nextFreshness, searchMode === 'web' ? 5 : 10, searchMode)
   }
 
   const handleReset = () => {


### PR DESCRIPTION
Closes #142

## Summary
- retain the active freshness selection when an AI suggestion is clicked
- keep explicit freshness values from normal submissions as the current filter
- add a component regression test covering suggestion searches

## Validation
- `git diff --check`
- Focused Vitest test is configured but dependencies are not installed in this environment.