### PR TITLE
Complete serverless AI chat JSON and SSE handling

### DIFF
--- a/api/ai/chat.ts
+++ b/api/ai/chat.ts
@@ -1,48 +1,38 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import Groq from 'groq-sdk'
 import { readServerConfig } from '../../src/lib/config'
+import { executeChatCompletion, formatAiError, streamChatCompletion, validateChatMessages, type ChatMessage } from '../../src/lib/aiChatService'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' })
-  }
-
-  const { messages, model: requestedModel } = (req.body || {}) as {
-    messages?: any[]
-    model?: string
-  }
-
-  const validationError = validateChatMessages(messages)
-  if (validationError) {
-    return res.status(400).json({ error: validationError })
-  }
-
-  // Groq is an optional feature: keep paid search deployable without its key.
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  const body = (req.body || {}) as { messages?: unknown; model?: string; stream?: boolean }
+  const validationError = validateChatMessages(body.messages)
+  if (validationError) return res.status(400).json({ error: validationError })
   const groqApiKey = readServerConfig().groqApiKey
   if (!groqApiKey) return res.status(503).json({ error: 'AI assistant is not configured.' })
   const groq = new Groq({ apiKey: groqApiKey })
+  const messages = body.messages as ChatMessage[]
+  const wantsStream = body.stream === true || (req.headers.accept || '').includes('text/event-stream')
 
-  try {
-    const stream = await streamChatCompletion(
-      groq,
-      {
-        messages: messages!,
-        model,
-      },
-      controller.signal
-    )
-
-    for await (const chunk of stream) {
-      const delta = chunk.choices?.[0]?.delta?.content
-      if (delta) sendEvent('delta', { content: delta })
-    }
-    sendEvent('done', { model })
-    res.end()
-  } catch (err: any) {
-    if (controller.signal.aborted) return res.end()
-    console.error('[groq stream error]', err?.message)
-    const formatted = formatAiError(err)
-    sendEvent('error', { error: formatted.message })
-    res.end()
+  if (!wantsStream) {
+    try { return res.json(await executeChatCompletion(groq, { messages, model: body.model })) }
+    catch (error) { return res.status(500).json({ error: formatAiError(error).message }) }
   }
+
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache, no-transform')
+  res.setHeader('Connection', 'keep-alive')
+  const controller = new AbortController()
+  if (typeof (req as { on?: Function }).on === 'function') (req as { on: Function }).on('close', () => controller.abort())
+  const send = (event: string, data: Record<string, unknown>) => res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+  try {
+    const stream = await streamChatCompletion(groq, { messages, model: body.model }, controller.signal)
+    for await (const chunk of stream) {
+      const content = chunk.choices?.[0]?.delta?.content
+      if (content) send('delta', { content })
+    }
+    send('done', {})
+  } catch (error) {
+    if (!controller.signal.aborted) send('error', { error: formatAiError(error).message })
+  } finally { res.end() }
 }

--- a/docs/ai-chat-testing.md
+++ b/docs/ai-chat-testing.md
@@ -1,0 +1,6 @@
+# AI chat adapter contract
+
+The Express and Vercel `/ai/chat` handlers use the same runtime-neutral chat
+service for message validation, model selection, JSON completion fallback, and
+SSE streaming. Tests mock Groq at the service boundary so behavior can be
+verified without network calls.


### PR DESCRIPTION
Closes #195

## Summary
- repair the Vercel AI handler so it uses the shared validation, model, JSON, and streaming service
- support JSON fallback and SSE delta/done/error events consistently
- abort upstream streaming when the client disconnects
- add adapter contract documentation

## Validation
- `git diff --check`
- Existing AI handler tests are configured but dependencies are not installed in this environment.