### PR TITLE
Share and cover query validation across HTTP adapters

### DIFF
--- a/api/search.ts
+++ b/api/search.ts
@@ -5,6 +5,7 @@ import {
 } from '../src/lib/constants'
 import { consumePaymentPayload } from '../src/lib/paymentIntegrity'
 import { formatConfigurationError, readServerConfig } from '../src/lib/config'
+import { validateQuery } from '../src/lib/queryValidation'
 
 // ─── Config ───────────────────────────────────────────────────────────────
 let config
@@ -47,10 +48,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const { q, count = '5', freshness } = req.query as Record<string, string>
 
-  if (!q?.trim()) {
-    const errorBody: ApiErrorResponse = { error: 'Missing required parameter: q' }
+  const validation = validateQuery(q)
+  if (!validation.ok) {
+    const errorBody: ApiErrorResponse = { error: validation.error }
     return res.status(400).json(errorBody)
   }
+  const cleanQ = validation.cleanQ
 
   // ─── Payment check ────────────────────────────────────────────────────────
   const paymentHeader =
@@ -114,7 +117,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     // ─── Serper.dev ──────────────────────────────────────────────────────────
     const requestBody: Record<string, unknown> = {
-      q:   q.trim(),
+      q:   cleanQ,
       num: Math.min(parseInt(count) || 5, 20),
     }
 
@@ -147,7 +150,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const latencyMs    = Date.now() - t0
 
     const results = normalizeOrganicResults(data)
-    const queryMeta = normalizeQueryMetadata(data, q.trim())
+    const queryMeta = normalizeQueryMetadata(data, cleanQ)
 
     const responseBody: SearchResponse = {
       query:          queryMeta.executedQuery,

--- a/docs/query-validation.md
+++ b/docs/query-validation.md
@@ -1,0 +1,5 @@
+# Query validation
+
+`src/lib/queryValidation.ts` is the side-effect-free validator shared by the
+Express and Vercel search adapters. It trims input, preserves Unicode, removes
+ASCII controls, rejects empty values, and enforces the 256-character boundary.

--- a/server/index.ts
+++ b/server/index.ts
@@ -55,6 +55,7 @@ import type {
 } from '../src/types/index.js'
 import { buildReconciliationRecord, type ReconciliationRoute } from '../src/lib/reconciliation.js'
 import { appendReconciliationRecord } from './reconciliationStore.js'
+import { validateQuery, MAX_QUERY_LENGTH } from '../src/lib/queryValidation.js'
 
 dotenv.config()
 
@@ -394,28 +395,7 @@ function recordReconciliation(params: {
   }
 }
 
-export const MAX_QUERY_LENGTH = 256
-
-// Validate and sanitize the user-supplied `q` parameter. Returns either the
-// cleaned string or a 400 response body to send back. Centralised so /search
-// and /images share the same rules.
-export function validateQuery(
-  q: unknown,
-): { ok: true; cleanQ: string } | { ok: false; error: string } {
-  if (typeof q !== 'string' || !q.trim()) {
-    return { ok: false, error: 'Missing required parameter: q' }
-  }
-  if (q.length > MAX_QUERY_LENGTH) {
-    return { ok: false, error: `Query too long. Maximum ${MAX_QUERY_LENGTH} characters.` }
-  }
-  // Strip null bytes and ASCII control characters (C0 + DEL) to prevent
-  // log injection and odd Serper behavior.
-  const cleanQ = q.replace(/[\x00-\x1F\x7F]/g, '').trim()
-  if (!cleanQ) {
-    return { ok: false, error: 'Query contains no valid characters.' }
-  }
-  return { ok: true, cleanQ }
-}
+export { validateQuery, MAX_QUERY_LENGTH }
 
 // ─── GET /search ──────────────────────────────────────────────────────────
 app.get('/search', async (req: Request, res: Response) => {

--- a/src/lib/queryValidation.ts
+++ b/src/lib/queryValidation.ts
@@ -1,0 +1,18 @@
+export const MAX_QUERY_LENGTH = 256
+
+export type QueryValidation =
+  | { ok: true; cleanQ: string }
+  | { ok: false; error: string }
+
+/** Shared, side-effect-free validation for Express and Vercel search routes. */
+export function validateQuery(q: unknown): QueryValidation {
+  if (typeof q !== 'string' || !q.trim()) {
+    return { ok: false, error: 'Missing required parameter: q' }
+  }
+  if (q.length > MAX_QUERY_LENGTH) {
+    return { ok: false, error: `Query too long. Maximum ${MAX_QUERY_LENGTH} characters.` }
+  }
+  const cleanQ = q.replace(/[\x00-\x1F\x7F]/g, '').trim()
+  if (!cleanQ) return { ok: false, error: 'Query contains no valid characters.' }
+  return { ok: true, cleanQ }
+}


### PR DESCRIPTION
Closes #187

## Summary
- extract side-effect-free query validation into `src/lib/queryValidation.ts`
- use the validator from Express and Vercel search routes
- preserve Unicode while rejecting controls, empty queries, and overlong input
- document the contract and keep direct table-driven coverage

## Validation
- `git diff --check`
- Existing validator tests are configured but dependencies are not installed in this environment.