### PR TITLE
fix: initialize MCP Groq client lazily

### DIFF
--- a/docs/mcp-ai-configuration.md
+++ b/docs/mcp-ai-configuration.md
@@ -1,0 +1,6 @@
+# MCP AI configuration
+
+The MCP server does not construct a Groq client during startup. The client is
+created only when `ai_summarize` runs and a `GROQ_API_KEY` is configured.
+Non-AI tools such as `check_balance` and `get_search_stats` therefore remain
+available when the optional AI key is absent.

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -54,7 +54,12 @@ try {
 const SERVER_URL = config.searchApiUrl
 const GROQ_API_KEY = config.groqApiKey
 
-const groq = GROQ_API_KEY ? new Groq({ apiKey: GROQ_API_KEY }) : undefined
+let groq: Groq | undefined
+function getGroq(): Groq | undefined {
+  if (!GROQ_API_KEY) return undefined
+  groq ??= new Groq({ apiKey: GROQ_API_KEY })
+  return groq
+}
 
 /** Clamp a search count to [min, max], falling back to defaultValue on NaN/fractional/negative. */
 export function clampCount(
@@ -677,12 +682,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   // ── ai_summarize ──────────────────────────────────────────────────────
   if (name === 'ai_summarize') {
     const { text, instruction = 'summarise' } = args as { text: string; instruction?: string }
-    if (!groq) {
+    const aiClient = getGroq()
+    if (!aiClient) {
       return { content: [{ type: 'text', text: 'AI summarization is not configured.' }], isError: true }
     }
 
     try {
-      const completion = await groq.chat.completions.create({
+      const completion = await aiClient.chat.completions.create({
         model: 'llama-3.3-70b-versatile',
         messages: [
           { role: 'system', content: 'You are a concise research assistant. Be brief and accurate.' },


### PR DESCRIPTION
Closes #174

## Summary
- implement the requested fix: initialize mcp groq client lazily
- preserve existing runtime behavior and project conventions
- document the behavior where applicable

## Validation
- git diff --check
- Focused local tooling was unavailable where dependencies are not installed in the clone.