### PR TITLE
fix: react to Freighter network changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Browser (Freighter) → GET /search?q=...
 
 Before signing, a bounded preflight verifies the active account, expected network, USDC trustline, spendable amount, and signer availability. If any check fails, no payment payload is created and the user gets a single targeted recovery action (e.g. "Add USDC", "Switch to testnet", or "Enable signer").
 
+While connected, the browser watches Freighter for account/network updates. A network switch immediately updates the search controls and cancels any in-flight payment creation before its signature can be sent. Express, Vercel, and MCP paid-route settlement remain unchanged: only the browser-side request is stopped before submission.
+
 | Preflight check | Required state | Targeted recovery action |
 |---|---|---|
 | Active account | A Freighter account is selected | Connect Freighter and select an account |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,8 @@ export default function App() {
   // Lifted so the floating GroqAssistant can read the last completed search
   // and pre-populate context (issue #57).
   const { session, search, reset } = useSearch(
-    wallet.connected ? wallet.publicKey : null
+    wallet.connected ? wallet.publicKey : null,
+    wallet.network,
   )
 
   const lastSearch = useMemo(

--- a/src/hooks/useFreighterWallet.test.ts
+++ b/src/hooks/useFreighterWallet.test.ts
@@ -226,6 +226,18 @@ describe('useFreighterWallet — wallet payment readiness', () => {
     expect(result.current.wallet.accountStatus).toBe('funded')
   })
 
+  it('updates the connected wallet network when Freighter reports a change', async () => {
+    mockIsConnected.mockResolvedValue({ isConnected: true })
+    mockRequestAccess.mockResolvedValue({})
+    const { result } = renderHook(() => useFreighterWallet())
+    await act(async () => { await result.current.connect() })
+
+    expect(mockWatch).toHaveBeenCalledTimes(1)
+    act(() => { triggerWatcher({ address: TEST_ADDRESS, network: 'PUBLIC' }) })
+
+    await waitFor(() => expect(result.current.wallet.network).toBe('PUBLIC'))
+  })
+
   it('handles unfunded account (404 / NotFoundError) cleanly as unfunded state', async () => {
     mockIsConnected.mockResolvedValue({ isConnected: true })
     mockRequestAccess.mockResolvedValue({})

--- a/src/hooks/useFreighterWallet.ts
+++ b/src/hooks/useFreighterWallet.ts
@@ -10,6 +10,7 @@ import {
   requestAccess,
   getAddress,
   getNetwork,
+  WatchWalletChanges,
 } from '@stellar/freighter-api'
 import { Horizon } from '@stellar/stellar-sdk'
 import { HORIZON_URL, USDC_ISSUER } from '../lib/stellar'
@@ -235,6 +236,28 @@ export function useFreighterWallet() {
     }
     check()
   }, [fetchBalances, fetchTransactions])
+
+  // Freighter only reports the selected network during a request unless we
+  // explicitly watch for changes. Keep the UI in sync so callers can stop a
+  // payment flow before a signature from the old network is submitted.
+  useEffect(() => {
+    if (typeof window === 'undefined' || window.__STELLAR_SEARCH_E2E_WALLET__) {
+      return
+    }
+
+    const watcher = new WatchWalletChanges()
+    watcher.watch(({ network }) => {
+      if (!network) return
+
+      setWallet(prev => (
+        prev.connected && prev.network !== network
+          ? { ...prev, network, error: null }
+          : prev
+      ))
+    })
+
+    return () => watcher.stop()
+  }, [])
 
   return {
     wallet,

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -181,6 +181,35 @@ describe('useSearch — lazy-loaded x402 payment flow (#336)', () => {
     vi.unstubAllGlobals()
   })
 
+  it('cancels payment creation when the wallet network changes', async () => {
+    let resolvePayment!: (value: unknown) => void
+    mockCreatePaymentPayload.mockReturnValueOnce(new Promise(resolve => {
+      resolvePayment = resolve
+    }))
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 402,
+      headers: { get: () => null },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, rerender } = renderHook(
+      ({ network }) => useSearch(WALLET, network),
+      { initialProps: { network: 'TESTNET' } },
+    )
+    let searchPromise: Promise<void>
+    act(() => { searchPromise = result.current.search('paid query') })
+    await waitFor(() => expect(mockCreatePaymentPayload).toHaveBeenCalledTimes(1))
+
+    rerender({ network: 'PUBLIC' })
+    resolvePayment({ payload: 'signed' })
+    await act(async () => { await searchPromise! })
+
+    expect(result.current.session.status).toBe('error')
+    expect(result.current.session.error).toMatch(/network changed/i)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    vi.unstubAllGlobals()
+  })
+
   it('blocks the search before any payment when the session cap is exceeded (#313)', async () => {
     // Exhaust the default 0.01 USDC session cap (10 × 0.001 settled searches).
     for (let i = 0; i < 10; i++) settleSpend('0.001')

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -10,7 +10,7 @@
  * Fix: convert Buffer → base64 string using Buffer.from(result).toString('base64')
  */
 
-import { useState, useCallback }              from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { toast }                               from 'sonner'
 import { x402Client, x402HTTPClient }          from '@x402/fetch'
 import { ExactStellarScheme }                  from '@x402/stellar/exact/client'
@@ -64,13 +64,59 @@ export interface SearchSession {
   suggestions: string[]
 }
 
-export function useSearch(walletAddress: string | null = null) {
+interface ActivePayment {
+  controller: AbortController
+  cancelled: boolean
+}
+
+const NETWORK_CHANGED_MESSAGE = 'Freighter network changed. Payment creation was cancelled; switch back and try again.'
+
+export function useSearch(
+  walletAddress: string | null = null,
+  walletNetwork?: string,
+) {
   const [session, setSession] = useState<SearchSession>({
     query: '', results: [], txHash: null, paidAmount: null, status: 'idle', suggestions: [],
   })
+  const activePaymentRef = useRef<ActivePayment | null>(null)
+  const previousNetworkRef = useRef(walletNetwork)
+
+  const cancelActivePayment = useCallback((message = NETWORK_CHANGED_MESSAGE) => {
+    const activePayment = activePaymentRef.current
+    if (!activePayment) return
+
+    activePayment.cancelled = true
+    activePayment.controller.abort()
+    setSession(prev => prev.status === 'searching'
+      ? { ...prev, status: 'error', error: message }
+      : prev)
+  }, [])
+
+  // A Freighter network switch invalidates any in-progress payment payload.
+  // `createPaymentPayload` itself cannot be aborted by the wallet API, so we
+  // invalidate its result and abort network requests before it can be sent.
+  useEffect(() => {
+    const previousNetwork = previousNetworkRef.current
+    previousNetworkRef.current = walletNetwork
+
+    if (previousNetwork && walletNetwork && previousNetwork !== walletNetwork) {
+      cancelActivePayment()
+    }
+  }, [walletNetwork, cancelActivePayment])
 
   const search = useCallback(async (query: string, count = 5) => {
     if (!query.trim()) return
+
+    const activePayment: ActivePayment = {
+      controller: new AbortController(),
+      cancelled: false,
+    }
+    activePaymentRef.current = activePayment
+    const throwIfCancelled = () => {
+      if (activePayment.cancelled || activePayment.controller.signal.aborted) {
+        throw new Error(NETWORK_CHANGED_MESSAGE)
+      }
+    }
 
     setSession({ query, results: [], txHash: null, paidAmount: null, status: 'searching', step: 1, suggestions: [] })
 
@@ -82,12 +128,16 @@ export function useSearch(walletAddress: string | null = null) {
 
     try {
       if (!walletAddress) throw new Error('Connect your Freighter wallet first.')
+      if (walletNetwork && walletNetwork !== EXPECTED_WALLET_NETWORK) {
+        throw new Error(`Switch Freighter to ${EXPECTED_WALLET_NETWORK}. Currently: ${walletNetwork}`)
+      }
 
       console.log('🔍 Starting search with wallet:', walletAddress)
 
       // Step 1 — verify Freighter is on correct network
       if (!(typeof window !== 'undefined' && window.__STELLAR_SEARCH_E2E_WALLET__)) {
         const net = await getNetworkDetails()
+        throwIfCancelled()
         if (net.error)              throw new Error(net.error.message)
         if (net.network !== EXPECTED_WALLET_NETWORK) {
           throw new Error(`Switch Freighter to ${EXPECTED_WALLET_NETWORK}. Currently: ${net.network}`)
@@ -136,7 +186,10 @@ export function useSearch(walletAddress: string | null = null) {
       // Flow step 1 — initial request, expect 402
       advance(1)
       console.log('🚀 Initial request:', `${SERVER_URL}/search?${params}`)
-      const firstRes = await fetch(`${SERVER_URL}/search?${params}`)
+      const firstRes = await fetch(`${SERVER_URL}/search?${params}`, {
+        signal: activePayment.controller.signal,
+      })
+      throwIfCancelled()
       console.log('📡 Status:', firstRes.status)
 
       if (firstRes.status !== 402) {
@@ -160,6 +213,7 @@ export function useSearch(walletAddress: string | null = null) {
       advance(3)
       console.log('🔐 Triggering Freighter popup via createPaymentPayload...')
       const paymentPayload = await client.createPaymentPayload(paymentRequired)
+      throwIfCancelled()
       console.log('✅ Freighter approved, payload created')
 
       const paymentHeaders = httpClient.encodePaymentSignatureHeader(paymentPayload)
@@ -170,11 +224,13 @@ export function useSearch(walletAddress: string | null = null) {
       console.log('🔄 Retrying with payment...')
       const paidResPromise = fetch(`${SERVER_URL}/search?${params}`, {
         headers: paymentHeaders,
+        signal: activePayment.controller.signal,
       })
 
       // Flow step 5 — facilitator settles on Stellar while the retry is in flight
       advance(5)
       const paidRes = await paidResPromise
+      throwIfCancelled()
       console.log('📡 Paid response status:', paidRes.status)
 
       if (!paidRes.ok) {
@@ -231,6 +287,7 @@ export function useSearch(walletAddress: string | null = null) {
       }
 
     } catch (err: any) {
+      if (activePayment.cancelled) return
       console.error('❌ Search failed:', err)
       const msg = err.message || 'Search failed.'
       toast.error('Search Payment Failed', { description: msg })
@@ -239,12 +296,16 @@ export function useSearch(walletAddress: string | null = null) {
         status: 'error',
         error:  msg,
       }))
+    } finally {
+      if (activePaymentRef.current === activePayment) {
+        activePaymentRef.current = null
+      }
     }
-  }, [walletAddress])
+  }, [walletAddress, walletNetwork])
 
   const reset = useCallback(() => {
     setSession({ query: '', results: [], txHash: null, paidAmount: null, status: 'idle', suggestions: [] })
   }, [])
 
-  return { session, search, reset }
+  return { session, search, reset, cancelActivePayment }
 }


### PR DESCRIPTION
## Description

Closes #128 

Adds real-time Freighter network-change handling. The browser now updates wallet network state promptly and cancels an in-flight payment creation before a signature for the previous network can be submitted. Documents that server-side x402 settlement behavior remains unchanged.

## Change Type

- [x] Code change (feature, bug fix, refactor)
- [ ] Documentation only change

---

## Change Scope & Verification Checklist

### For Code & Behavior Changes

- [x] **Tests & Coverage**: Added coverage for Freighter network updates and cancellation during payment creation.
- [x] **API Contract & Parity**: Browser cancellation occurs before submission; Express, Vercel, and MCP settlement behavior is unchanged.
- [x] **x402 Protocol & Settlement**: Preserved existing x402 payment requirements and payment-signature handling.
- [x] **Wallet Integration**: Uses `WatchWalletChanges` from `@stellar/freighter-api`.
- [x] **Accessibility (a11y)**: Existing mismatch messaging and disabled search controls continue to reflect the live wallet network.
- [ ] **Screenshots / Visual Evidence**: Not attached; behavior reuses existing UI.
- [x] **Rollback Strategy**: Revert commit `40e81cc` to restore previous connection-time-only network checks.

### For Documentation-Only Changes

- [ ] **Accuracy & Verification**: Not applicable.
- [x] **No Secrets Leak**: No secrets added.

---

## Security & Secrets Audit

- [x] Confirmed no private keys, secret seeds, or real API keys are committed in code or logs.